### PR TITLE
fix: check for \n in CodeMirror runmode

### DIFF
--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -170,3 +170,31 @@ describe('highlight mode', () => {
     expect(node.find('.cm-linerow.cm-overlay')).toHaveLength(6);
   });
 });
+
+describe('runmode', () => {
+  let node;
+  const code = `CURL *hnd = curl_easy_init();\n\nurl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");\n\ncurl_easy_setopt(hnd, CURLOPT_URL, "http://httpbin.orgpet/");`;
+
+  beforeEach(() => {
+    node = mount(
+      syntaxHighlighter(code, 'c', {
+        dark: true,
+        highlightMode: true,
+        tokenizeVariables: true,
+        ranges: [
+          [
+            { ch: 0, line: 0 },
+            { ch: 0, line: 1 },
+          ],
+        ],
+      })
+    );
+  });
+
+  it('should display the correct number of lines with multiple linebreaks', () => {
+    const checkLineBreaks = parseInt(node.find('.cm-linerow').last().find('.cm-lineNumber').text(), 10);
+    const totalLines = code.split('\n');
+
+    expect(checkLineBreaks).toStrictEqual(totalLines.length);
+  });
+});

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -172,7 +172,8 @@ const ReadmeCodeMirror = (code, lang, opts = { tokenizeVariables: false, highlig
   }
 
   CodeMirror.runMode(code, mode, (text, style) => {
-    if (style !== curStyle) {
+    const lineBreakRegex = /\r?\n/;
+    if (style !== curStyle || lineBreakRegex.test(text)) {
       flush();
       curStyle = style;
       accum = text;


### PR DESCRIPTION
[Asana Ticket](https://app.asana.com/0/1177736375805705/1198569009223205) 

## 🧰 What's being changed?

For every language except node, putting in an empty line will cause two empty lines to show up in readOnly mode. This seems to be caused when the if and then else statements are hit on consecutive newline characters

## 🧪 Testing
change the code string in public/index.js to one of the following:

`CURL *hnd = curl_easy_init();\n\ncurl_easy_setopt(hnd, CURLOPT_CUSTOMREQUEST, "GET");\n\ncurl_easy_setopt(hnd, CURLOPT_URL, "http://httpbin.orgpet/");\n\nCURLcode ret = curl_easy_perform(hnd);`, 'c'

`import requests\n\nurl = "http://httpbin.orgpet/"\n\nresponse = requests.request("HEAD", url)\n\nprint(response.text) `, 'python'

