### PR TITLE
fix: isolating regex check to highlightmode option

### DIFF
--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -173,7 +173,7 @@ const ReadmeCodeMirror = (code, lang, opts = { tokenizeVariables: false, highlig
 
   CodeMirror.runMode(code, mode, (text, style) => {
     const lineBreakRegex = /\r?\n/;
-    if (style !== curStyle || lineBreakRegex.test(text)) {
+    if (style !== curStyle || (opts.highlightMode && lineBreakRegex.test(text))) {
       flush();
       curStyle = style;
       accum = text;


### PR DESCRIPTION
## 🧰 What's being changed?

Previous fix brought in `newline` regexp check in our `codeMirror.runmode()` call. This could potentially lead to some side-effects that were not planning for. Updating this logic to check for our `opt.highlightMode` flag as well.
