### PR TITLE
feat(themes): add support for a light theme

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -4,7 +4,7 @@ import syntaxHighlighter, { cmVariableContext } from '../src/index';
 
 ReactDOM.render(
   <div>
-    <h1>Core Syntax Highlighter</h1>
+    <h1>Core Syntax Highlighter (Dark Theme)</h1>
     <pre id="hub-reference">
       <cmVariableContext.Provider
         value={{
@@ -42,7 +42,45 @@ ReactDOM.render(
       </cmVariableContext.Provider>
     </pre>
     <hr />
-    <h1>Code Editor</h1>
+    <h1>Core Syntax Highlighter (Light Theme)</h1>
+    <pre id="hub-reference">
+      <cmVariableContext.Provider
+        value={{
+          user: {},
+          defaults: [
+            {
+              name: 'url',
+              default: 'GET',
+            },
+          ],
+        }}
+      >
+        {syntaxHighlighter(
+          `curl --request POST
+          --url <<url>>
+          --header 'authorization: Bearer 123'
+          --header 'content-type: application/json'`,
+          'curl',
+          {
+            dark: false,
+            highlightMode: true,
+            tokenizeVariables: true,
+            ranges: [
+              [
+                { ch: 0, line: 0 },
+                { ch: 0, line: 1 },
+              ],
+              [
+                { ch: 0, line: 4 },
+                { ch: 0, line: 5 },
+              ],
+            ],
+          }
+        )}
+      </cmVariableContext.Provider>
+    </pre>
+    <hr />
+    <h1>Code Editor (Dark Theme)</h1>
     <pre id="hub-reference">
       {syntaxHighlighter(
         `curl --request POST
@@ -51,6 +89,18 @@ ReactDOM.render(
         --header 'content-type: application/json'`,
         'curl',
         { editable: true, dark: true }
+      )}
+    </pre>
+    <hr />
+    <h1>Code Editor (Light Theme)</h1>
+    <pre id="hub-reference">
+      {syntaxHighlighter(
+        `curl --request POST
+        --url http://petstore.swagger.io/v2/pet
+        --header 'authorization: Bearer 123'
+        --header 'content-type: application/json'`,
+        'curl',
+        { editable: true, dark: false }
       )}
     </pre>
   </div>,

--- a/src/codeEditor/index.jsx
+++ b/src/codeEditor/index.jsx
@@ -6,7 +6,7 @@ import defaults from './cm.options';
 import '../utils/cm-mode-imports';
 import './style.scss';
 
-const CodeEditor = ({ className, code, lang, options, children, ...attr }) => {
+const CodeEditor = ({ className, code, lang, options, children, theme, ...attr }) => {
   const [value, setValue] = useState(children && typeof children === 'string' ? children : code);
   const [mode, setMode] = useState(getMode(lang));
 
@@ -28,7 +28,7 @@ const CodeEditor = ({ className, code, lang, options, children, ...attr }) => {
       {...attr}
       className="CodeEditor"
       onBeforeChange={(editor, data, updatedCode) => setValue(updatedCode)}
-      options={{ ...defaults, ...options, mode }}
+      options={{ ...defaults, ...options, mode, theme }}
       value={value}
     />
   );
@@ -48,14 +48,14 @@ CodeEditor.propTypes = {
   options: PropTypes.object,
   /** Syntax highlighting theme.
    */
-  theme: PropTypes.oneOf(['light', 'dark']),
+  theme: PropTypes.oneOf(['neo', 'material-palenight']),
 };
 
 CodeEditor.defaultProps = {
   className: '',
   code: '',
   options: {},
-  theme: 'dark',
+  theme: 'material-palenight',
 };
 
 export default CodeEditor;

--- a/src/codeEditor/style.scss
+++ b/src/codeEditor/style.scss
@@ -1,4 +1,5 @@
 .CodeEditor {
   @import '~codemirror/lib/codemirror.css';
   @import '~codemirror/theme/material-palenight.css';
+  @import '~codemirror/theme/neo.css';
 }

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -120,7 +120,7 @@ const StyledSyntaxHighlighter = ({ output, ranges }) => {
 
   const highlights = ranges && ranges.length ? highlightedLines(ranges, gutteredOutput.length) : [];
   return (
-    <div className="CodeMirror cm-s-material-palenight">
+    <div className="CodeMirror">
       <StructuredOutput gutteredInput={gutteredOutput} highlights={highlights} />
     </div>
   );

--- a/src/codeMirror/style.scss
+++ b/src/codeMirror/style.scss
@@ -1,18 +1,56 @@
 $gutterWidth: 43px; // enough for 3 chars
 
+// dark theme
+$darkBackground: #242e34;
+$darkColor: #fff;
+$darkHightlight: rgba(#000, 0.25);
+
+// light theme
+$lightBackground: #fff;
+$lightColor: #000;
+$lightHighlight: rgba($lightColor, 0.1);
+
 .CodeEditor {
-  &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay {
-    color: rgba(255, 255, 255, 0.5);
+
+  &.cm-s-material-palenight {
+
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay,
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay > span,
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay > p {
+      color: rgba($darkColor, 0.5);
+    }
+
+    .cm-highlight {
+      background: $darkHightlight;
+    }
+
+    .CodeMirror {
+      background: $darkBackground;
+      color: $darkColor;
+    }
+  }
+
+  &.cm-s-neo {
+
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay,
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay > span,
+    &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay > p {
+      color: rgba($lightColor, 0.5);
+    }
+
+    .cm-highlight {
+      background: $lightHighlight;
+    }
+
+    .CodeMirror {
+      background: $lightBackground;
+      color: $lightColor;
+    }
+  }
+
+  &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay,
+  &:not(:hover):not(:active):not(:focus) .cm-linerow.cm-overlay .cm-lineNumber {
     opacity: 0.75;
-
-    > span,
-    > p {
-      color: rgba(255, 255, 255, 0.5);
-    }
-
-    .cm-lineNumber {
-      opacity: 0.75;
-    }
   }
 }
 
@@ -20,11 +58,6 @@ $gutterWidth: 43px; // enough for 3 chars
   position: relative;
   text-indent: $gutterWidth + 4px;
   transition: background 0.5s cubic-bezier(0.16, 1, 0.3, 1), color 0.5s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.5s cubic-bezier(0.16, 1, 0.3, 1);
-
-  &.cm-highlight {
-    background: rgba(0, 0, 0, 0.25);
-  }
-
 
   > span,
   > p {

--- a/src/index.js
+++ b/src/index.js
@@ -11,20 +11,19 @@ const SyntaxHighlighter = (
   opts = { dark: false, tokenizeVariables: false, editable: false },
   editorProps = {}
 ) => {
+  const theme = opts.dark ? 'material-palenight' : 'neo';
+
   if (opts.editable) {
     return React.createElement(codeEditor, {
       ...editorProps,
       code,
       lang,
+      theme,
     });
   }
 
   let classes = '';
-  if (opts.highlightMode) {
-    classes = 'CodeEditor cm-s-material-palenight';
-  } else {
-    classes = opts.dark ? 'cm-s-tomorrow-night' : 'cm-s-neo';
-  }
+  if (opts.highlightMode) classes = `CodeEditor cm-s-${theme}`;
 
   return React.createElement(
     'div',


### PR DESCRIPTION
Adds support for light theme (Neo); which is the same theme we use in the dash.

<img width="665" alt="Screen Shot 2020-11-17 at 10 58 51 AM" src="https://user-images.githubusercontent.com/5341618/99434668-e58eb200-28c3-11eb-9de5-2a5701061d83.png">
<img width="657" alt="Screen Shot 2020-11-17 at 10 58 47 AM" src="https://user-images.githubusercontent.com/5341618/99434672-e6bfdf00-28c3-11eb-922c-f7694a3886ab.png">
