### PR TITLE
feat: adding support for custom themes

### DIFF
--- a/public/index.js
+++ b/public/index.js
@@ -2,9 +2,16 @@ import React from 'react';
 import ReactDOM from 'react-dom';
 import syntaxHighlighter, { cmVariableContext } from '../src/index';
 
+const exampleCode = `curl --request POST
+  --url <<url>>
+  --header 'authorization: Bearer 123'
+  --header 'content-type: application/json'`;
+
 ReactDOM.render(
   <div>
-    <h1>Core Syntax Highlighter (Dark Theme)</h1>
+    <h1>Core Syntax Highlighter</h1>
+
+    <h2>Dark Theme</h2>
     <pre id="hub-reference">
       <cmVariableContext.Provider
         value={{
@@ -17,32 +24,25 @@ ReactDOM.render(
           ],
         }}
       >
-        {syntaxHighlighter(
-          `curl --request POST
-          --url <<url>>
-          --header 'authorization: Bearer 123'
-          --header 'content-type: application/json'`,
-          'curl',
-          {
-            dark: true,
-            highlightMode: true,
-            tokenizeVariables: true,
-            ranges: [
-              [
-                { ch: 0, line: 0 },
-                { ch: 0, line: 1 },
-              ],
-              [
-                { ch: 0, line: 4 },
-                { ch: 0, line: 5 },
-              ],
+        {syntaxHighlighter(exampleCode, 'curl', {
+          dark: true,
+          highlightMode: true,
+          tokenizeVariables: true,
+          ranges: [
+            [
+              { ch: 0, line: 0 },
+              { ch: 0, line: 1 },
             ],
-          }
-        )}
+            [
+              { ch: 0, line: 4 },
+              { ch: 0, line: 5 },
+            ],
+          ],
+        })}
       </cmVariableContext.Provider>
     </pre>
-    <hr />
-    <h1>Core Syntax Highlighter (Light Theme)</h1>
+
+    <h2>Light Theme</h2>
     <pre id="hub-reference">
       <cmVariableContext.Provider
         value={{
@@ -55,53 +55,66 @@ ReactDOM.render(
           ],
         }}
       >
-        {syntaxHighlighter(
-          `curl --request POST
-          --url <<url>>
-          --header 'authorization: Bearer 123'
-          --header 'content-type: application/json'`,
-          'curl',
-          {
-            dark: false,
-            highlightMode: true,
-            tokenizeVariables: true,
-            ranges: [
-              [
-                { ch: 0, line: 0 },
-                { ch: 0, line: 1 },
-              ],
-              [
-                { ch: 0, line: 4 },
-                { ch: 0, line: 5 },
-              ],
+        {syntaxHighlighter(exampleCode, 'curl', {
+          dark: false,
+          highlightMode: true,
+          tokenizeVariables: true,
+          ranges: [
+            [
+              { ch: 0, line: 0 },
+              { ch: 0, line: 1 },
             ],
-          }
-        )}
+            [
+              { ch: 0, line: 4 },
+              { ch: 0, line: 5 },
+            ],
+          ],
+        })}
       </cmVariableContext.Provider>
     </pre>
-    <hr />
-    <h1>Code Editor (Dark Theme)</h1>
+
+    <h2>Custom Theme: tomorrow-night</h2>
     <pre id="hub-reference">
-      {syntaxHighlighter(
-        `curl --request POST
-        --url http://petstore.swagger.io/v2/pet
-        --header 'authorization: Bearer 123'
-        --header 'content-type: application/json'`,
-        'curl',
-        { editable: true, dark: true }
-      )}
+      <cmVariableContext.Provider
+        value={{
+          user: {},
+          defaults: [
+            {
+              name: 'url',
+              default: 'GET',
+            },
+          ],
+        }}
+      >
+        {syntaxHighlighter(exampleCode, 'curl', {
+          customTheme: 'tomorrow-night',
+          highlightMode: true,
+          tokenizeVariables: true,
+          ranges: [
+            [
+              { ch: 0, line: 0 },
+              { ch: 0, line: 1 },
+            ],
+            [
+              { ch: 0, line: 4 },
+              { ch: 0, line: 5 },
+            ],
+          ],
+        })}
+      </cmVariableContext.Provider>
     </pre>
+
     <hr />
-    <h1>Code Editor (Light Theme)</h1>
+    <h1>Code Editor</h1>
+    <h2>Dark Theme</h2>
+    <pre id="hub-reference">{syntaxHighlighter(exampleCode, 'curl', { editable: true, dark: true })}</pre>
+
+    <h2>Light Theme</h2>
+    <pre id="hub-reference">{syntaxHighlighter(exampleCode, 'curl', { editable: true, dark: false })}</pre>
+
+    <h2>Custom Theme: tomorrow-night</h2>
     <pre id="hub-reference">
-      {syntaxHighlighter(
-        `curl --request POST
-        --url http://petstore.swagger.io/v2/pet
-        --header 'authorization: Bearer 123'
-        --header 'content-type: application/json'`,
-        'curl',
-        { editable: true, dark: false }
-      )}
+      {syntaxHighlighter(exampleCode, 'curl', { editable: true, customTheme: 'tomorrow-night' })}
     </pre>
   </div>,
   document.getElementById('root')

--- a/src/codeEditor/index.jsx
+++ b/src/codeEditor/index.jsx
@@ -48,7 +48,7 @@ CodeEditor.propTypes = {
   options: PropTypes.object,
   /** Syntax highlighting theme.
    */
-  theme: PropTypes.oneOf(['neo', 'material-palenight']),
+  theme: PropTypes.oneOf(['neo', 'material-palenight', 'tomorrow-night']),
 };
 
 CodeEditor.defaultProps = {

--- a/src/index.js
+++ b/src/index.js
@@ -8,10 +8,19 @@ import { modes } from './utils/modes';
 const SyntaxHighlighter = (
   code,
   lang,
-  opts = { dark: false, tokenizeVariables: false, editable: false },
+  opts = {
+    // If `customTheme` is present, it will override the `dark` option.
+    customTheme: false,
+    dark: false,
+    tokenizeVariables: false,
+    editable: false,
+  },
   editorProps = {}
 ) => {
-  const theme = opts.dark ? 'material-palenight' : 'neo';
+  let theme = opts.dark ? 'material-palenight' : 'neo';
+  if (opts.customTheme) {
+    theme = opts.customTheme;
+  }
 
   if (opts.editable) {
     return React.createElement(codeEditor, {


### PR DESCRIPTION
## 🧰 What's being changed?

https://github.com/readmeio/syntax-highlighter/pull/38 removed support for `tomorrow-night` on non-editable instances of this library, this adds support for a new `customTheme` parameter to bring it back.
