### PR TITLE
fix: allow for bare variable substitution

### DIFF
--- a/__tests__/__snapshots__/codeMirror.test.js.snap
+++ b/__tests__/__snapshots__/codeMirror.test.js.snap
@@ -346,3 +346,12 @@ exports[`Supported languages cURL should syntax highlight an example 1`] = `
   <span class=\\"cm-attribute\\">--header</span> <span class=\\"cm-string\\">&#x27;x-readme-version: v3.0&#x27;</span>
 </div>"
 `;
+
+exports[`should tokenize variables outside of quotes over multple lines 1`] = `
+"
+  const foo = APIKEY;
+  const bar = NAME;
+
+  fetch({ foo, bar, baz: TOKEN });
+"
+`;

--- a/__tests__/__snapshots__/codeMirror.test.js.snap
+++ b/__tests__/__snapshots__/codeMirror.test.js.snap
@@ -347,7 +347,7 @@ exports[`Supported languages cURL should syntax highlight an example 1`] = `
 </div>"
 `;
 
-exports[`should tokenize variables outside of quotes over multple lines 1`] = `
+exports[`should tokenize variables outside of quotes over multiple lines 1`] = `
 "
   const foo = APIKEY;
   const bar = NAME;

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -62,16 +62,12 @@ test('should keep enclosing characters around the variable', () => {
 
 test('should tokenize variables outside of quotes', () => {
   const codeBlock = `
-\`\`\`
   const foo = <<apiKey>>;
   const bar = <<name>>;
-\`\`\`
 `;
   const expected = `
-\`\`\`
   const foo = APIKEY;
   const bar = NAME;
-\`\`\`
 `;
   expect(mount(syntaxHighlighter(codeBlock, 'json', { tokenizeVariables: true })).text()).toBe(expected);
   expect(mount(syntaxHighlighter('<<apiKey>>', 'json', { tokenizeVariables: true })).text()).toBe('APIKEY');

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -71,14 +71,14 @@ test('should tokenize variables outside of quotes over multple lines', () => {
 
   fetch({ foo, bar, baz: <<token>> });
 `;
-  const expected = `
-  const foo = APIKEY;
-  const bar = NAME;
 
-  fetch({ foo, bar, baz: TOKEN });
-`;
+  expect(mount(syntaxHighlighter(codeBlock, 'json', { tokenizeVariables: true })).text()).toMatchSnapshot();
+});
 
-  expect(mount(syntaxHighlighter(codeBlock, 'json', { tokenizeVariables: true })).text()).toBe(expected);
+test('should tokenize multiple variables per line', () => {
+  expect(mount(syntaxHighlighter('<<apiKey>> <<name>>', 'json', { tokenizeVariables: true })).text()).toBe(
+    'APIKEY NAME'
+  );
 });
 
 describe('Supported languages', () => {

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -61,16 +61,24 @@ test('should keep enclosing characters around the variable', () => {
 });
 
 test('should tokenize variables outside of quotes', () => {
+  expect(mount(syntaxHighlighter('<<apiKey>>', 'json', { tokenizeVariables: true })).text()).toBe('APIKEY');
+});
+
+test('should tokenize variables outside of quotes over multple lines', () => {
   const codeBlock = `
   const foo = <<apiKey>>;
   const bar = <<name>>;
+
+  fetch({ foo, bar, baz: <<token>> });
 `;
   const expected = `
   const foo = APIKEY;
   const bar = NAME;
+
+  fetch({ foo, bar, baz: TOKEN });
 `;
+
   expect(mount(syntaxHighlighter(codeBlock, 'json', { tokenizeVariables: true })).text()).toBe(expected);
-  expect(mount(syntaxHighlighter('<<apiKey>>', 'json', { tokenizeVariables: true })).text()).toBe('APIKEY');
 });
 
 describe('Supported languages', () => {

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -60,6 +60,10 @@ test('should keep enclosing characters around the variable', () => {
   expect(mount(syntaxHighlighter("'<<apiKey>>'", 'json', { tokenizeVariables: true })).text()).toBe("'APIKEY'");
 });
 
+test("should tokenize variables outside of quotes", () => {
+  expect(mount(syntaxHighlighter("<<apiKey>>", 'json', { tokenizeVariables: true })).text()).toBe("APIKEY");
+})
+
 describe('Supported languages', () => {
   const languages = fixtures.map(fixture => {
     return [uppercase(path.basename(fixture)), fixture];

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -66,7 +66,7 @@ test('should tokenize variables outside of quotes', () => {
   expect(mount(syntaxHighlighter('<<apiKey>>', 'json', { tokenizeVariables: true })).text()).toBe('APIKEY');
 });
 
-test('should tokenize variables outside of quotes over multple lines', () => {
+test('should tokenize variables outside of quotes over multiple lines', () => {
   const codeBlock = `
   const foo = <<apiKey>>;
   const bar = <<name>>;

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -60,9 +60,22 @@ test('should keep enclosing characters around the variable', () => {
   expect(mount(syntaxHighlighter("'<<apiKey>>'", 'json', { tokenizeVariables: true })).text()).toBe("'APIKEY'");
 });
 
-test("should tokenize variables outside of quotes", () => {
-  expect(mount(syntaxHighlighter("<<apiKey>>", 'json', { tokenizeVariables: true })).text()).toBe("APIKEY");
-})
+test('should tokenize variables outside of quotes', () => {
+  const codeBlock = `
+\`\`\`
+  const foo = <<apiKey>>;
+  const bar = <<name>>;
+\`\`\`
+`;
+  const expected = `
+\`\`\`
+  const foo = APIKEY;
+  const bar = NAME;
+\`\`\`
+`;
+  expect(mount(syntaxHighlighter(codeBlock, 'json', { tokenizeVariables: true })).text()).toBe(expected);
+  expect(mount(syntaxHighlighter('<<apiKey>>', 'json', { tokenizeVariables: true })).text()).toBe('APIKEY');
+});
 
 describe('Supported languages', () => {
   const languages = fixtures.map(fixture => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -2374,9 +2374,9 @@
       }
     },
     "@babel/runtime-corejs3": {
-      "version": "7.11.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.11.2.tgz",
-      "integrity": "sha512-qh5IR+8VgFz83VBa6OkaET6uN/mJOhHONuy3m1sgF0CV6mXdPSEBdA7e1eUbVvyNtANjMbg22JUv71BaDXLY6A==",
+      "version": "7.12.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.12.5.tgz",
+      "integrity": "sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==",
       "dev": true,
       "requires": {
         "core-js-pure": "^3.0.0",
@@ -3173,6 +3173,32 @@
         "chalk": "^4.0.0"
       }
     },
+    "@nodelib/fs.scandir": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
+      "integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "2.0.3",
+        "run-parallel": "^1.1.9"
+      }
+    },
+    "@nodelib/fs.stat": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
+      "integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+      "dev": true
+    },
+    "@nodelib/fs.walk": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
+      "integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.scandir": "2.1.3",
+        "fastq": "^1.6.0"
+      }
+    },
     "@npmcli/move-file": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@npmcli/move-file/-/move-file-1.0.1.tgz",
@@ -3191,23 +3217,23 @@
       }
     },
     "@readme/eslint-config": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-3.4.2.tgz",
-      "integrity": "sha512-PLDsDnm+cTxpIjZBxQOyFZ/rUaQdtInDeNSPb1F58/AUMuEPmxbDqpmT1uKAgnSDjJkYiYEBu4AYaeusk7/fOQ==",
+      "version": "3.6.5",
+      "resolved": "https://registry.npmjs.org/@readme/eslint-config/-/eslint-config-3.6.5.tgz",
+      "integrity": "sha512-AgDccX0eJRlCLjDcV/uH5jml4RPcSbAcEjXgYpc+aGuaeNdwQ58SudTsFqSXm7D95OEhs1SAZYx0FwfOLRqhaw==",
       "dev": true,
       "requires": {
         "eslint-config-airbnb-base": "^14.0.0",
         "eslint-config-prettier": "^6.5.0",
         "eslint-plugin-eslint-comments": "^3.1.2",
         "eslint-plugin-import": "^2.18.2",
-        "eslint-plugin-jest": "^23.1.1",
+        "eslint-plugin-jest": "^24.0.0",
         "eslint-plugin-jest-formatting": "^2.0.0",
         "eslint-plugin-jsx-a11y": "^6.2.3",
         "eslint-plugin-node": "^11.1.0",
         "eslint-plugin-prettier": "^3.1.1",
         "eslint-plugin-react": "^7.17.0",
         "eslint-plugin-sonarjs": "^0.5.0",
-        "eslint-plugin-unicorn": "^21.0.0"
+        "eslint-plugin-unicorn": "^23.0.0"
       }
     },
     "@readme/variable": {
@@ -3464,38 +3490,87 @@
       "dev": true
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.34.0.tgz",
-      "integrity": "sha512-eS6FTkq+wuMJ+sgtuNTtcqavWXqsflWcfBnlYhg/nS4aZ1leewkXGbvBhaapn1q6qf4M71bsR1tez5JTRMuqwA==",
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-4.8.1.tgz",
+      "integrity": "sha512-WigyLn144R3+lGATXW4nNcDJ9JlTkG8YdBWHkDlN0lC3gUGtDi7Pe3h5GPvFKMcRz8KbZpm9FJV9NTW8CpRHpg==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.34.0",
+        "@typescript-eslint/scope-manager": "4.8.1",
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/typescript-estree": "4.8.1",
         "eslint-scope": "^5.0.0",
         "eslint-utils": "^2.0.0"
       }
     },
-    "@typescript-eslint/typescript-estree": {
-      "version": "2.34.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.34.0.tgz",
-      "integrity": "sha512-OMAr+nJWKdlVM9LOqCqh3pQQPwxHAN7Du8DR6dmwCrAmxtiXQnhHJ6tBNtf+cggqfo51SG/FCwnKhXCIM7hnVg==",
+    "@typescript-eslint/scope-manager": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-4.8.1.tgz",
+      "integrity": "sha512-r0iUOc41KFFbZdPAdCS4K1mXivnSZqXS5D9oW+iykQsRlTbQRfuFRSW20xKDdYiaCoH+SkSLeIF484g3kWzwOQ==",
       "dev": true,
       "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/visitor-keys": "4.8.1"
+      }
+    },
+    "@typescript-eslint/types": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-4.8.1.tgz",
+      "integrity": "sha512-ave2a18x2Y25q5K05K/U3JQIe2Av4+TNi/2YuzyaXLAsDx6UZkz1boZ7nR/N6Wwae2PpudTZmHFXqu7faXfHmA==",
+      "dev": true
+    },
+    "@typescript-eslint/typescript-estree": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-4.8.1.tgz",
+      "integrity": "sha512-bJ6Fn/6tW2g7WIkCWh3QRlaSU7CdUUK52shx36/J7T5oTQzANvi6raoTsbwGM11+7eBbeem8hCCKbyvAc0X3sQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "@typescript-eslint/visitor-keys": "4.8.1",
         "debug": "^4.1.1",
-        "eslint-visitor-keys": "^1.1.0",
-        "glob": "^7.1.6",
+        "globby": "^11.0.1",
         "is-glob": "^4.0.1",
         "lodash": "^4.17.15",
         "semver": "^7.3.2",
         "tsutils": "^3.17.1"
       },
       "dependencies": {
+        "array-union": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+          "integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==",
+          "dev": true
+        },
+        "globby": {
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/globby/-/globby-11.0.1.tgz",
+          "integrity": "sha512-iH9RmgwCmUJHi2z5o2l3eTtGBtXek1OYlHrbcxOYugyHLmAsZrPj43OtHThd62Buh/Vv6VyCBD2bdyWcGNQqoQ==",
+          "dev": true,
+          "requires": {
+            "array-union": "^2.1.0",
+            "dir-glob": "^3.0.1",
+            "fast-glob": "^3.1.1",
+            "ignore": "^5.1.4",
+            "merge2": "^1.3.0",
+            "slash": "^3.0.0"
+          }
+        },
         "semver": {
           "version": "7.3.2",
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
           "integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==",
           "dev": true
         }
+      }
+    },
+    "@typescript-eslint/visitor-keys": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-4.8.1.tgz",
+      "integrity": "sha512-3nrwXFdEYALQh/zW8rFwP4QltqsanCDz4CwWMPiIZmwlk9GlvBeueEIbq05SEq4ganqM0g9nh02xXgv5XI3PeQ==",
+      "dev": true,
+      "requires": {
+        "@typescript-eslint/types": "4.8.1",
+        "eslint-visitor-keys": "^2.0.0"
       }
     },
     "@webassemblyjs/ast": {
@@ -4026,14 +4101,55 @@
       }
     },
     "array.prototype.flatmap": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.3.tgz",
-      "integrity": "sha512-OOEk+lkePcg+ODXIpvuU9PAryCikCJyo7GlDG1upleEpQRx6mzL9puEBkozQ5iAx20KV0l3DbyQwqciJtqe5Pg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/array.prototype.flatmap/-/array.prototype.flatmap-1.2.4.tgz",
+      "integrity": "sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
+        "es-abstract": "^1.18.0-next.1",
         "function-bind": "^1.1.1"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "arrify": {
@@ -4180,9 +4296,9 @@
       "dev": true
     },
     "axe-core": {
-      "version": "3.5.5",
-      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-3.5.5.tgz",
-      "integrity": "sha512-5P0QZ6J5xGikH780pghEdbEKijCTrruK9KxtPZCFWUpef0f6GipO+xEZ5GKCb020mmqgbiNO6TcA55CriL784Q==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.1.1.tgz",
+      "integrity": "sha512-5Kgy8Cz6LPC9DJcNb3yjAXTu3XihQgEdnIg50c//zOC/MyLP0Clg+Y8Sh9ZjjnvBrDZU4DgXS9C3T9r4/scGZQ==",
       "dev": true
     },
     "axobject-query": {
@@ -4205,12 +4321,28 @@
         "resolve": "^1.12.0"
       },
       "dependencies": {
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        },
+        "is-core-module": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+          "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
           "dev": true,
           "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -4875,6 +5007,16 @@
         "unset-value": "^1.0.0"
       }
     },
+    "call-bind": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.0.tgz",
+      "integrity": "sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "get-intrinsic": "^1.0.0"
+      }
+    },
     "callsites": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
@@ -5285,9 +5427,9 @@
       }
     },
     "confusing-browser-globals": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.9.tgz",
-      "integrity": "sha512-KbS1Y0jMtyPgIxjO7ZzMAuUpAKMt1SzCL9fsrKsX6b0zJPTaT0SiSPmewwVZg9UAO83HVIlEhZF84LIjZ0lmAw==",
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/confusing-browser-globals/-/confusing-browser-globals-1.0.10.tgz",
+      "integrity": "sha512-gNld/3lySHwuhaVluJUKLePYirM3QNCKzVxqAdhJII9/WXKVX5PURzMVJspS1jTslSqjeuG4KMVTSouit5YPHA==",
       "dev": true
     },
     "connect-history-api-fallback": {
@@ -5833,9 +5975,9 @@
       }
     },
     "core-js-pure": {
-      "version": "3.6.5",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.6.5.tgz",
-      "integrity": "sha512-lacdXOimsiD0QyNf9BC/mxivNJ/ybBGJXQFKzRekp1WTHoVUWsUHEn+2T8GJAzzIhyOuXA+gOxCVN3l+5PLPUA==",
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.7.0.tgz",
+      "integrity": "sha512-EZD2ckZysv8MMt4J6HSvS9K2GdtlZtdBncKAmF9lr2n0c9dJUaUN88PSTjvgwCgQPWKTkERXITgS6JJRAnljtg==",
       "dev": true
     },
     "core-util-is": {
@@ -6333,6 +6475,23 @@
           "version": "4.11.9",
           "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.9.tgz",
           "integrity": "sha512-E6QoYqCKZfgatHTdHzs1RRKP7ip4vvm+EyRUeE2RF0NblwVvb0p6jSVeNTOFxPn26QXN2o6SMfNxKp6kU8zQaw==",
+          "dev": true
+        }
+      }
+    },
+    "dir-glob": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+      "integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+      "dev": true,
+      "requires": {
+        "path-type": "^4.0.0"
+      },
+      "dependencies": {
+        "path-type": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+          "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
           "dev": true
         }
       }
@@ -7023,20 +7182,34 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.2.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
-      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
+      "version": "14.2.1",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.1.tgz",
+      "integrity": "sha512-GOrQyDtVEc1Xy20U7vsB2yAoB4nBlfH5HZJeatRXHleO+OS5Ot+MWij4Dpltw4/DyIkqUfqz1epfhVR5XWWQPA==",
       "dev": true,
       "requires": {
-        "confusing-browser-globals": "^1.0.9",
-        "object.assign": "^4.1.0",
+        "confusing-browser-globals": "^1.0.10",
+        "object.assign": "^4.1.2",
         "object.entries": "^1.1.2"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "eslint-config-prettier": {
-      "version": "6.11.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.11.0.tgz",
-      "integrity": "sha512-oB8cpLWSAjOVFEJhhyMZh6NOEOtBVziaqdDQ86+qhDHFbZXoRTM7pNSvFRfW/W/L/LrQ38C99J5CGuRBBzBsdA==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-6.15.0.tgz",
+      "integrity": "sha512-a1+kOYLR8wMGustcgAjdydMsQ2A/2ipRPwRKUmfYaSxc9ZPcrku080Ctl6zrZzZNs/U82MjSv+qKREkoq3bJaw==",
       "dev": true,
       "requires": {
         "get-stdin": "^6.0.0"
@@ -7069,12 +7242,22 @@
             "ms": "2.0.0"
           }
         },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "is-core-module": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+          "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
           "dev": true,
           "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -7122,9 +7305,9 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.22.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
-      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
+      "version": "2.22.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.1.tgz",
+      "integrity": "sha512-8K7JjINHOpH64ozkAhpT3sd+FswIZTfMZTjdx052pnWrgRCVfp8op9tbjpAk3DdUeI/Ba4C8OjdC0r90erHEOw==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
@@ -7132,7 +7315,7 @@
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-import-resolver-node": "^0.3.4",
         "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
@@ -7151,24 +7334,34 @@
             "ms": "2.0.0"
           }
         },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "is-core-module": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+          "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
           "dev": true,
           "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
       }
     },
     "eslint-plugin-jest": {
-      "version": "23.20.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-23.20.0.tgz",
-      "integrity": "sha512-+6BGQt85OREevBDWCvhqj1yYA4+BFK4XnRZSGJionuEYmcglMZYLNNBBemwzbqUAckURaHdJSBcjHPyrtypZOw==",
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
+      "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "^2.5.0"
+        "@typescript-eslint/experimental-utils": "^4.0.1"
       }
     },
     "eslint-plugin-jest-formatting": {
@@ -7178,28 +7371,28 @@
       "dev": true
     },
     "eslint-plugin-jsx-a11y": {
-      "version": "6.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.3.1.tgz",
-      "integrity": "sha512-i1S+P+c3HOlBJzMFORRbC58tHa65Kbo8b52/TwCwSKLohwvpfT5rm2GjGWzOHTEuq4xxf2aRlHHTtmExDQOP+g==",
+      "version": "6.4.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.4.1.tgz",
+      "integrity": "sha512-0rGPJBbwHoGNPU73/QCLP/vveMlM1b1Z9PponxO87jfr6tuH5ligXbDT6nHSSzBC8ovX2Z+BQu7Bk5D/Xgq9zg==",
       "dev": true,
       "requires": {
-        "@babel/runtime": "^7.10.2",
+        "@babel/runtime": "^7.11.2",
         "aria-query": "^4.2.2",
         "array-includes": "^3.1.1",
         "ast-types-flow": "^0.0.7",
-        "axe-core": "^3.5.4",
-        "axobject-query": "^2.1.2",
+        "axe-core": "^4.0.2",
+        "axobject-query": "^2.2.0",
         "damerau-levenshtein": "^1.0.6",
         "emoji-regex": "^9.0.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
+        "jsx-ast-utils": "^3.1.0",
         "language-tags": "^1.0.5"
       },
       "dependencies": {
         "emoji-regex": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.0.0.tgz",
-          "integrity": "sha512-6p1NII1Vm62wni/VR/cUMauVQoxmLVb9csqQlvLz+hO2gk8U2UYDfXHQSUYIBKmZwAKz867IDqG7B+u0mj+M6w==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.0.tgz",
+          "integrity": "sha512-DNc3KFPK18bPdElMJnf/Pkv5TXhxFU3YFDEuGLDRtPmV4rkmCjBkCSEp22u6rBHdSN9Vlp/GK7k98prmE1Jgug==",
           "dev": true
         }
       }
@@ -7236,21 +7429,21 @@
       }
     },
     "eslint-plugin-react": {
-      "version": "7.20.6",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.20.6.tgz",
-      "integrity": "sha512-kidMTE5HAEBSLu23CUDvj8dc3LdBU0ri1scwHBZjI41oDv4tjsWZKU7MQccFzH1QYPYhsnTF2ovh7JlcIcmxgg==",
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.21.5.tgz",
+      "integrity": "sha512-8MaEggC2et0wSF6bUeywF7qQ46ER81irOdWS4QWxnnlAEsnzeBevk1sWh7fhpCghPpXb+8Ks7hvaft6L/xsR6g==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
         "array.prototype.flatmap": "^1.2.3",
         "doctrine": "^2.1.0",
         "has": "^1.0.3",
-        "jsx-ast-utils": "^2.4.1",
+        "jsx-ast-utils": "^2.4.1 || ^3.0.0",
         "object.entries": "^1.1.2",
         "object.fromentries": "^2.0.2",
         "object.values": "^1.1.1",
         "prop-types": "^15.7.2",
-        "resolve": "^1.17.0",
+        "resolve": "^1.18.1",
         "string.prototype.matchall": "^4.0.2"
       },
       "dependencies": {
@@ -7263,12 +7456,22 @@
             "esutils": "^2.0.2"
           }
         },
-        "resolve": {
-          "version": "1.17.0",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-          "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+        "is-core-module": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.1.0.tgz",
+          "integrity": "sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==",
           "dev": true,
           "requires": {
+            "has": "^1.0.3"
+          }
+        },
+        "resolve": {
+          "version": "1.19.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.19.0.tgz",
+          "integrity": "sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==",
+          "dev": true,
+          "requires": {
+            "is-core-module": "^2.1.0",
             "path-parse": "^1.0.6"
           }
         }
@@ -7281,18 +7484,18 @@
       "dev": true
     },
     "eslint-plugin-unicorn": {
-      "version": "21.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-21.0.0.tgz",
-      "integrity": "sha512-S8v7+v4gZTQPj4pKKvexhgSUaLQSyItvxW2SVZDaX9Iu5IjlAmF2eni+L6w8a2aqshxgU8Lle4FIAVDtuejSKQ==",
+      "version": "23.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-unicorn/-/eslint-plugin-unicorn-23.0.0.tgz",
+      "integrity": "sha512-Vabo3cjl6cjyhcf+76CdQEY6suOFzK0Xh3xo0uL9VDYrDJP5+B6PjV0tHTYm82WZmFWniugFJM3ywHSNYTi/ZQ==",
       "dev": true,
       "requires": {
         "ci-info": "^2.0.0",
         "clean-regexp": "^1.0.0",
         "eslint-ast-utils": "^1.1.0",
-        "eslint-template-visitor": "^2.0.0",
+        "eslint-template-visitor": "^2.2.1",
         "eslint-utils": "^2.1.0",
         "import-modules": "^2.0.0",
-        "lodash": "^4.17.15",
+        "lodash": "^4.17.20",
         "pluralize": "^8.0.0",
         "read-pkg-up": "^7.0.1",
         "regexp-tree": "^0.1.21",
@@ -7301,14 +7504,11 @@
         "semver": "^7.3.2"
       },
       "dependencies": {
-        "eslint-utils": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
-          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
+        "lodash": {
+          "version": "4.17.20",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+          "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==",
+          "dev": true
         },
         "parse-json": {
           "version": "5.1.0",
@@ -7371,13 +7571,32 @@
       }
     },
     "eslint-scope": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.0.tgz",
-      "integrity": "sha512-iiGRvtxWqgtx5m8EyQUJihBloE4EnYeGE/bz1wSPwJE6tZuJUtHlhqDM4Xj2ukE8Dyy1+HCZ4hE0fzIVMzb58w==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-5.1.1.tgz",
+      "integrity": "sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==",
       "dev": true,
       "requires": {
-        "esrecurse": "^4.1.0",
+        "esrecurse": "^4.3.0",
         "estraverse": "^4.1.1"
+      },
+      "dependencies": {
+        "esrecurse": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
+          "integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^5.2.0"
+          },
+          "dependencies": {
+            "estraverse": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.2.0.tgz",
+              "integrity": "sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==",
+              "dev": true
+            }
+          }
+        }
       }
     },
     "eslint-template-visitor": {
@@ -7401,18 +7620,26 @@
       }
     },
     "eslint-utils": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+      "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
+      },
+      "dependencies": {
+        "eslint-visitor-keys": {
+          "version": "1.3.0",
+          "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
+          "integrity": "sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==",
+          "dev": true
+        }
       }
     },
     "eslint-visitor-keys": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz",
-      "integrity": "sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-2.0.0.tgz",
+      "integrity": "sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==",
       "dev": true
     },
     "espree": {
@@ -7806,6 +8033,20 @@
       "integrity": "sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==",
       "dev": true
     },
+    "fast-glob": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.4.tgz",
+      "integrity": "sha512-kr/Oo6PX51265qeuCYsyGypiO5uJFgBS0jksyG7FUeCyQzNwYnzrNIMR1NXfkZXsMYXYLRAHgISHBz8gQcxKHQ==",
+      "dev": true,
+      "requires": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.0",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.2",
+        "picomatch": "^2.2.1"
+      }
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -7817,6 +8058,15 @@
       "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
       "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
       "dev": true
+    },
+    "fastq": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.9.0.tgz",
+      "integrity": "sha512-i7FVWL8HhVY+CTkwFxkN2mk3h+787ixS5S63eb78diVRc1MCssarHq3W5cj0av7YDSwmaV928RNag+U1etRQ7w==",
+      "dev": true,
+      "requires": {
+        "reusify": "^1.0.4"
+      }
     },
     "faye-websocket": {
       "version": "0.10.0",
@@ -8457,6 +8707,17 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
+    },
+    "get-intrinsic": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.0.1.tgz",
+      "integrity": "sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==",
+      "dev": true,
+      "requires": {
+        "function-bind": "^1.1.1",
+        "has": "^1.0.3",
+        "has-symbols": "^1.0.1"
+      }
     },
     "get-package-type": {
       "version": "0.1.0",
@@ -10914,13 +11175,27 @@
       }
     },
     "jsx-ast-utils": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-2.4.1.tgz",
-      "integrity": "sha512-z1xSldJ6imESSzOjd3NNkieVJKRlKYSOtMG8SFyCj2FIrvSaSuli/WjpBkEzCBoR9bYYYFgqJw61Xhu7Lcgk+w==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsx-ast-utils/-/jsx-ast-utils-3.1.0.tgz",
+      "integrity": "sha512-d4/UOjg+mxAWxCiF0c5UTSwyqbchkbqCvK87aBovhnh8GtysTjWmgC63tY0cJx/HzGgm9qnA147jVBdpOiQ2RA==",
       "dev": true,
       "requires": {
         "array-includes": "^3.1.1",
-        "object.assign": "^4.1.0"
+        "object.assign": "^4.1.1"
+      },
+      "dependencies": {
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "killable": {
@@ -10948,9 +11223,9 @@
       "dev": true
     },
     "language-subtag-registry": {
-      "version": "0.3.20",
-      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.20.tgz",
-      "integrity": "sha512-KPMwROklF4tEx283Xw0pNKtfTj1gZ4UByp4EsIFWLgBavJltF4TiYPc39k06zSTsLzxTVXXDSpbwaQXaFB4Qeg==",
+      "version": "0.3.21",
+      "resolved": "https://registry.npmjs.org/language-subtag-registry/-/language-subtag-registry-0.3.21.tgz",
+      "integrity": "sha512-L0IqwlIXjilBVVYKFT37X9Ih11Um5NEl9cbJIuU/SwP/zEEAbBPOnEeeuxVMf45ydWQRDQN3Nqc96OgbH1K+Pg==",
       "dev": true
     },
     "language-tags": {
@@ -11337,6 +11612,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
+    },
+    "merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
       "dev": true
     },
     "methods": {
@@ -13792,6 +14073,12 @@
       "integrity": "sha1-G0KmJmoh8HQh0bC1S33BZ7AcATs=",
       "dev": true
     },
+    "reusify": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
+      "integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+      "dev": true
+    },
     "rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-3.0.2.tgz",
@@ -13825,6 +14112,12 @@
       "version": "4.8.5",
       "resolved": "https://registry.npmjs.org/rsvp/-/rsvp-4.8.5.tgz",
       "integrity": "sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==",
+      "dev": true
+    },
+    "run-parallel": {
+      "version": "1.1.10",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.10.tgz",
+      "integrity": "sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==",
       "dev": true
     },
     "run-queue": {
@@ -14508,23 +14801,41 @@
       },
       "dependencies": {
         "es-abstract": {
-          "version": "1.18.0-next.0",
-          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.0.tgz",
-          "integrity": "sha512-elZXTZXKn51hUBdJjSZGYRujuzilgXo8vSPQzjGYXLvSlGiCo8VO8ZGV3kjo9a0WNJJ57hENagwbtlRuHuzkcQ==",
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
           "dev": true,
           "requires": {
             "es-to-primitive": "^1.2.1",
             "function-bind": "^1.1.1",
             "has": "^1.0.3",
             "has-symbols": "^1.0.1",
-            "is-callable": "^1.2.0",
+            "is-callable": "^1.2.2",
             "is-negative-zero": "^2.0.0",
             "is-regex": "^1.1.1",
             "object-inspect": "^1.8.0",
             "object-keys": "^1.1.1",
-            "object.assign": "^4.1.0",
+            "object.assign": "^4.1.1",
             "string.prototype.trimend": "^1.0.1",
             "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
           }
         }
       }
@@ -15161,17 +15472,58 @@
       }
     },
     "string.prototype.matchall": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.2.tgz",
-      "integrity": "sha512-N/jp6O5fMf9os0JU3E72Qhf590RSRZU/ungsL/qJUYVTNv7hTG0P/dbPjxINVN9jpscu3nzYwKESU3P3RY5tOg==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.3.tgz",
+      "integrity": "sha512-OBxYDA2ifZQ2e13cP82dWFMaCV9CGF8GzmN4fljBVw5O5wep0lu4gacm1OL6MjROoUnB8VbkWRThqkV2YFLNxw==",
       "dev": true,
       "requires": {
+        "call-bind": "^1.0.0",
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0",
+        "es-abstract": "^1.18.0-next.1",
         "has-symbols": "^1.0.1",
         "internal-slot": "^1.0.2",
         "regexp.prototype.flags": "^1.3.0",
-        "side-channel": "^1.0.2"
+        "side-channel": "^1.0.3"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.18.0-next.1",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
+          "integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.2.2",
+            "is-negative-zero": "^2.0.0",
+            "is-regex": "^1.1.1",
+            "object-inspect": "^1.8.0",
+            "object-keys": "^1.1.1",
+            "object.assign": "^4.1.1",
+            "string.prototype.trimend": "^1.0.1",
+            "string.prototype.trimstart": "^1.0.1"
+          }
+        },
+        "is-callable": {
+          "version": "1.2.2",
+          "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.2.tgz",
+          "integrity": "sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==",
+          "dev": true
+        },
+        "object.assign": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.2.tgz",
+          "integrity": "sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==",
+          "dev": true,
+          "requires": {
+            "call-bind": "^1.0.0",
+            "define-properties": "^1.1.3",
+            "has-symbols": "^1.0.1",
+            "object-keys": "^1.1.1"
+          }
+        }
       }
     },
     "string.prototype.trim": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "@babel/preset-react": "^7.10.4",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@readme/eslint-config": "^3.2.0",
+    "@readme/eslint-config": "^3.6.5",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-module-resolver": "^4.0.0",

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -163,14 +163,15 @@ const extractVariables = (code, opts) => {
 
   let offsetDelta = 0;
   const variables = [];
-  const replacer = ({ length }, capture, offset) => {
+
+  const extracter = ({ length }, capture, offset) => {
     variables.push({ text: capture, offset: offset - offsetDelta });
     offsetDelta += length;
 
     return '';
   };
 
-  const codeWithoutVars = code.replace(new RegExp(VARIABLE_REGEXP, 'g'), replacer);
+  const codeWithoutVars = code.replace(new RegExp(VARIABLE_REGEXP, 'g'), extracter);
 
   return [codeWithoutVars, makeReinserter(variables)];
 };

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -130,8 +130,8 @@ const StyledSyntaxHighlighter = ({ output, ranges }) => {
  * ReadMe user variables are written like <<var>>. Depending on the
  * language parser used by CodeMirror, that could get parsed into
  * multiple tokens, ie ['<<', 'var', '>>']. So, we do a first pass to
- * remove the variables. And once CodeMirror has tokenized them, we can
- * reinsert them/ma.
+ * remove the variables. And reinsert them after CodeMirror has done its
+ * parsing.
  */
 const makeReinserter = variables => {
   let offset = 0;

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -126,51 +126,68 @@ const StyledSyntaxHighlighter = ({ output, ranges }) => {
   );
 };
 
-StyledSyntaxHighlighter.propTypes = {
-  output: PropTypes.arrayOf(PropTypes.any),
-  ranges: PropTypes.arrayOf(PropTypes.any),
-};
-
+/**
+ * Remove variables from a code block. Returns the text with the
+ * variables removed an array of variables and their insert positions.
+ *
+ * @arg {string} code
+ * @arg {object} opts
+ * @return {[string, {length: number, text: string, offset: number }[]]}
+ */
 const extractVariables = (code, opts) => {
   if (!opts.tokenizeVariables) return [code];
 
+  let offsetDelta = 0;
   const variables = [];
   const replacer = ({ length }, capture, offset) => {
-    variables.push({ length, text: capture, offset });
+    variables.push({ length, text: capture, offset: offset - offsetDelta });
+    offsetDelta += length;
+
     return '';
   };
+
   const codeWithoutVars = code.replace(new RegExp(VARIABLE_REGEXP, 'g'), replacer);
 
   return [codeWithoutVars, variables];
 };
 
+/**
+ * Reinsert variables into the styled code tokens.
+ * NOTE: modifies styled in place
+ *
+ * @arg {[string, string][]} styled - code tokens with style
+ * @arg {{length: Number, text: String, offset: Number }[]} variables - variables and their offsets
+ * @arg {object} opts
+ * @return {[string, string][]}
+ */
 const insertVariables = (styled, variables, opts) => {
   if (!opts.tokenizeVariables) return styled;
 
-  let absIndex = 0;
-  let currentVar = 0;
+  let offset = 0;
+  let index = 0;
+  let currentToken = styled[index][0];
 
-  return styled.map(([text, style], i) => {
-    let interpolated = text;
-
-    const variable = variables[currentVar] || {};
-    const index = variable.offset - absIndex;
-
-    if (index <= text.length) {
-      interpolated = [
-        text.slice(0, index),
-        <Variable key={`variable-${i}`} variable={variable.text} />,
-        text.slice(index),
-      ];
-
-      absIndex += variable.text.length + variable.length;
-      currentVar += 1;
+  variables.forEach((variable, i) => {
+    while (!(offset <= variable.offset && variable.offset <= offset + currentToken.length)) {
+      offset += currentToken.length;
+      index += 1;
+      currentToken = styled[index][0];
     }
 
-    absIndex += text.length;
-
-    return [interpolated, style];
+    const tokenOffset = variable.offset - offset;
+    styled[index][0] = [
+      currentToken.slice(0, tokenOffset),
+      <Variable key={`variable-${i}`} variable={variable.text} />,
+      currentToken.slice(tokenOffset),
+    ];
   });
+
+  return styled;
+};
+
+StyledSyntaxHighlighter.propTypes = {
+  output: PropTypes.arrayOf(PropTypes.any),
+  ranges: PropTypes.arrayOf(PropTypes.any),
 };
 
 /**


### PR DESCRIPTION
## 🧰 What's being changed?

ReadMe user variables are written like `<<var>>`. Depending on the
language parser used by CodeMirror, that could get parsed into
multiple tokens, ie [`<<`, `var`, `>>`]. So, we do a first pass to
remove the variables. And reinsert them after CodeMirror has done its
parsing.

This PR also fixes inserting multiple variables per line.

## 🧪 Testing

The following would not get interpolated:

```js
const foo = <<name>>;
```

Multiple variables (previously, only the second would get interpolated):
```js
const foo = { bar: <<name>>, baz: <<name>> };
```

[[bare variable ticket]](https://app.asana.com/0/1199089258199423/1198973877710478/f)
[[multiple variable ticket]](https://app.asana.com/0/1178132843162889/1179842282864914/f)