### PR TITLE
chore(deps): set variable as a peerDep

### DIFF
--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -47,15 +47,11 @@ test('should have a dark theme', () => {
 });
 
 test('should tokenize variables (double quotes)', () => {
-  expect(mount(syntaxHighlighter('"<<apiKey>>"', 'json', { tokenizeVariables: true })).find('Variable')).toHaveLength(
-    1
-  );
+  expect(mount(syntaxHighlighter('"<<apiKey>>"', 'json', { tokenizeVariables: true })).find(Variable)).toHaveLength(1);
 });
 
 test('should tokenize variables (single quotes)', () => {
-  expect(mount(syntaxHighlighter("'<<apiKey>>'", 'json', { tokenizeVariables: true })).find('Variable')).toHaveLength(
-    1
-  );
+  expect(mount(syntaxHighlighter("'<<apiKey>>'", 'json', { tokenizeVariables: true })).find(Variable)).toHaveLength(1);
 });
 
 test('should keep enclosing characters around the variable', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@readme/syntax-highlighter",
-  "version": "10.2.0",
+  "version": "10.3.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -3240,6 +3240,7 @@
       "version": "7.2.1",
       "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.2.1.tgz",
       "integrity": "sha512-I3/WoaVLaRmkLbnAwpm6pnBOzm5eDhpTLWa3D5eJUwEDsVSJVfbybJzdALHFbGkEpYX9somXSK00hhxxJ/dJ6A==",
+      "dev": true,
       "requires": {
         "classnames": "^2.2.6",
         "prop-types": "^15.7.2",
@@ -5172,7 +5173,8 @@
     "classnames": {
       "version": "2.2.6",
       "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.2.6.tgz",
-      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q=="
+      "integrity": "sha512-JR/iSQOSt+LQIWwrwEzJ9uk0xfN3mTVYMwt1Ir5mUcSN6pU+V4zQFFaJsclJbPuAUQH+yfWef6tm7l1quW3C8Q==",
+      "dev": true
     },
     "clean-css": {
       "version": "4.2.3",
@@ -13473,6 +13475,7 @@
       "version": "16.14.0",
       "resolved": "https://registry.npmjs.org/react/-/react-16.14.0.tgz",
       "integrity": "sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==",
+      "dev": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3237,14 +3237,13 @@
       }
     },
     "@readme/variable": {
-      "version": "7.2.1",
-      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-7.2.1.tgz",
-      "integrity": "sha512-I3/WoaVLaRmkLbnAwpm6pnBOzm5eDhpTLWa3D5eJUwEDsVSJVfbybJzdALHFbGkEpYX9somXSK00hhxxJ/dJ6A==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@readme/variable/-/variable-10.0.0.tgz",
+      "integrity": "sha512-YJ0ow5AicxrsCnlJvDiSoJoevKDS3kXLVVs1F7D6nV+uqQIWgQZNRc1VgLcrhZZukYFbGwc07TuPE7gaHa3yhA==",
       "dev": true,
       "requires": {
         "classnames": "^2.2.6",
-        "prop-types": "^15.7.2",
-        "react": "^16.4.2"
+        "prop-types": "^15.7.2"
       }
     },
     "@sinonjs/commons": {

--- a/package.json
+++ b/package.json
@@ -23,16 +23,17 @@
     "watch": "webpack -w --progress"
   },
   "dependencies": {
-    "@readme/variable": "^7.2.1",
     "codemirror": "^5.48.2",
     "prop-types": "^15.7.2",
     "react-codemirror2": "^7.2.1"
   },
   "peerDependencies": {
+    "@readme/variable": "^7.2.1",
     "react": "16.x",
     "react-dom": "16.x"
   },
   "devDependencies": {
+    "@readme/variable": "^7.2.1",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@commitlint/cli": "^11.0.0",

--- a/package.json
+++ b/package.json
@@ -28,17 +28,17 @@
     "react-codemirror2": "^7.2.1"
   },
   "peerDependencies": {
-    "@readme/variable": "^7.2.1",
+    "@readme/variable": "^10.0.0",
     "react": "16.x",
     "react-dom": "16.x"
   },
   "devDependencies": {
-    "@readme/variable": "^7.2.1",
     "@babel/preset-env": "^7.11.5",
     "@babel/preset-react": "^7.10.4",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
     "@readme/eslint-config": "^3.6.5",
+    "@readme/variable": "^10.0.0",
     "babel-jest": "^26.3.0",
     "babel-loader": "^8.1.0",
     "babel-plugin-module-resolver": "^4.0.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -39,6 +39,7 @@ const base = {
       amd: 'react-dom',
       umd: 'react-dom',
     },
+    '@readme/variable': '@readme/variable',
   },
   resolve: {
     extensions: ['.js', '.jsx'],


### PR DESCRIPTION
## 🧰 What's being changed?

This sets `@readme/variable` as a peerDep. Variable is using a context
to propagate user variables. So, it needs to be a singleton in the app,
otherwise any imported consumers won't be matched the correct provider.

## 🧪 Testing


