### PR TITLE
feat(syntax-highlighter): support classname

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -32,7 +32,11 @@ const SyntaxHighlighter = (
     });
   }
 
-  const classes = [`cm-s-${theme} ${opts.className ? opts.className : ''}`];
+  const classes = [`cm-s-${theme}`];
+  if (opts.className) {
+    classes.push(opts.className);
+  }
+
   if (opts.highlightMode) {
     classes.push('CodeEditor');
   }

--- a/src/index.js
+++ b/src/index.js
@@ -10,6 +10,7 @@ const SyntaxHighlighter = (
   lang,
   opts = {
     // If `customTheme` is present, it will override the `dark` option.
+    className: '',
     customTheme: false,
     dark: false,
     tokenizeVariables: false,
@@ -31,7 +32,7 @@ const SyntaxHighlighter = (
     });
   }
 
-  const classes = [`cm-s-${theme}`];
+  const classes = [`cm-s-${theme} ${opts.className ? opts.className : ''}`];
   if (opts.highlightMode) {
     classes.push('CodeEditor');
   }


### PR DESCRIPTION
To allow us to pass in classnames so we can style overflow for readonly. https://github.com/readmeio/ui/pull/468