### PR TITLE
fix: closing bracket in json with highlightMode enabled

### DIFF
--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -40,6 +40,18 @@ test('should work with modes', () => {
   );
 });
 
+test('should keep trailing json bracket if highlightMode is enabled', () => {
+  expect(
+    shallow(
+      syntaxHighlighter('{ "a": 1 }', 'json', {
+        highlightMode: true,
+      })
+    ).html()
+  ).toBe(
+    '<div class="cm-s-neo CodeEditor"><div class="CodeMirror"><div class="cm-linerow "><span class="cm-lineNumber">1</span>{ <span class="cm-property">&quot;a&quot;</span>: <span class="cm-number">1</span> }</div></div></div>'
+  );
+});
+
 test('should have a dark theme', () => {
   expect(shallow(syntaxHighlighter('{ "a": 1 }', 'json', { dark: true })).hasClass('cm-s-material-palenight')).toBe(
     true

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -86,7 +86,7 @@ const StyledSyntaxHighlighter = ({ output, ranges }) => {
 
   const enumerateMatches = (o, final) => {
     // Case where a single line break
-    if (o.length === 1) {
+    if (o.length === 1 && lineBreakRegex.test(o)) {
       incrementLine(true);
       // Case with multiple consecutive line breaks
     } else {


### PR DESCRIPTION
## 🧰 What's being changed?

I'm noticing a weird issue in the recipes modals where JSON response bodies like this:
```json
{"success":true}
```
would drop the closing bracket for some reason, so it'd render
```json
{"success":true
```
I isolated it down to an issue with the `<StyledSyntaxHighlighter />` component and created a test to account for this edge case.

## 🧪 Testing

If CI passes, we should be good!
