### PR TITLE
style(codemirror): add highlight class

### DIFF
--- a/src/codeMirror/style.scss
+++ b/src/codeMirror/style.scss
@@ -14,10 +14,12 @@ $lightHighlight: rgba($lightColor, 0.1);
 
   &.cm-s-material-palenight {
 
-    .cm-linerow.cm-overlay,
-    .cm-linerow.cm-overlay > span,
-    .cm-linerow.cm-overlay > p {
-      color: rgba($darkColor, 0.5);
+    &:not(.CodeEditor-Input_highlight) {
+      .cm-linerow.cm-overlay,
+      .cm-linerow.cm-overlay > span,
+      .cm-linerow.cm-overlay > p {
+        color: rgba($darkColor, 0.5);
+      }
     }
 
     .cm-highlight {
@@ -32,10 +34,12 @@ $lightHighlight: rgba($lightColor, 0.1);
 
   &.cm-s-neo {
 
-    .cm-linerow.cm-overlay,
-    .cm-linerow.cm-overlay > span,
-    .cm-linerow.cm-overlay > p {
-      color: rgba($lightColor, 0.5);
+    &:not(.CodeEditor-Input_highlight) {
+      .cm-linerow.cm-overlay,
+      .cm-linerow.cm-overlay > span,
+      .cm-linerow.cm-overlay > p {
+        color: rgba($lightColor, 0.5);
+      }
     }
 
     .cm-highlight {


### PR DESCRIPTION
## 🧰 What's being changed?

Won't dim code if .CodeEditor also has .CodeEditor-Input_highlight (you can test this by manually adding the class)

## 🧪 Testing

Provide as much information as you can on how to test what you've done.
