### PR TITLE
fix: loosen up our @readme/variable peerDep requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "react-codemirror2": "^7.2.1"
   },
   "peerDependencies": {
-    "@readme/variable": "^10.0.0",
+    "@readme/variable": "*",
     "react": "16.x",
     "react-dom": "16.x"
   },


### PR DESCRIPTION
## 🧰 What's being changed?

Just like I did with https://github.com/readmeio/markdown/pull/131, this loosens up our peerDep requirement on `@readme/variable`.