### PR TITLE
chore(options): add a new inline toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # @readme/syntax-highlighter
 
-ReadMe's React-based syntax highlighter based on [CodeMirror](https://github.com/codemirror/CodeMirror) and [react-codemirror2](https://github.com/scniro/react-codemirror2).
+ReadMe's React-based syntax highlighter based on [CodeMirror][codemirror] and [react-codemirror2][react-codemirror]
 
 [![npm](https://img.shields.io/npm/v/@readme/syntax-highlighter)](https://npm.im/@readme/syntax-highlighter) [![Build](https://github.com/readmeio/syntax-highlighter/workflows/CI/badge.svg)](https://github.com/readmeio/syntax-highlighter)
 
@@ -41,7 +41,7 @@ const ele = syntaxHighlighter('console.log("Hello, world!");', 'js', {
 ```
 
 ### Full CodeMirror
-Access to a full code Mirror instance. See configuration settings in the [react-codemirror2 library](https://github.com/scniro/react-codemirror2#props)
+Access to a full code Mirror instance. See configuration settings in the [`react-codemirror2` library][react-codemirror#props]
 
 ```js
 const syntaxHighlighter = require('@readme/syntax-highlighter');
@@ -51,12 +51,13 @@ const ele = syntaxHighlighter('console.log("Hello, world!");', 'js', { ...opts, 
 ### Available Options
 | Name | Type | Description |
 | :--- | :--- | :--- |
-| dark | boolean | Enable Dark Mode? |
-| highlightMode | boolean | Enable line number display and ability to set highlighted line css |
-| tokenizeVariables | boolean | Apply [Variable Component](https://github.com/readmeio/api-explorer/tree/next/packages/variable) to matched Regex |
-| ranges | array | Ranges of line numbers to apply highlighting to. Requires `highlightMode` enabled |
-| editable | boolean | Enable full CodeMirror Instance |
-| customTheme | string | A styling theme. Will override dark mode. Available options are 'neo', 'material-palenight', or 'tomorrow-night'.
+| `customTheme` | String | Highlighting theme. One of `neo`, `material-palenight`, or `tomorrow-night`. (Setting this will override the `dark` mode option.)
+| `dark` | Boolean | Enable dark mode. |
+| `editable` | Boolean | Enable the full CodeMirror instance |
+| `highlightMode` | Boolean | Enable line number display. |
+| `inline` | String | Wrap code in a `<span>` tag, instead of a `<div>`. |
+| `ranges` | Array | Ranges of line numbers to apply highlighting to. Requires `highlightMode` enabled |
+| `tokenizeVariables` | Boolean | Match and render [ReadMe variables](rdme-variable) in your markdown. |
 
 ## Languages Supported
 
@@ -100,3 +101,9 @@ const ele = syntaxHighlighter('console.log("Hello, world!");', 'js', { ...opts, 
 | TOML | `toml` |
 | TypeScript | `ts`, `typescript` |
 | YAML | `yaml`, `yml` |
+
+
+[rdme-variable]: https://github.com/readmeio/api-explorer/tree/next/packages/variable
+[codemirror]: https://github.com/codemirror/CodeMirror
+[react-codemirror]: https://github.com/scniro/react-codemirror2
+[react-codemirror#props]: https://github.com/scniro/react-codemirror2#props

--- a/src/index.js
+++ b/src/index.js
@@ -13,8 +13,9 @@ const SyntaxHighlighter = (
     className: '',
     customTheme: false,
     dark: false,
-    tokenizeVariables: false,
     editable: false,
+    inline: false,
+    tokenizeVariables: false,
   },
   editorProps = {}
 ) => {
@@ -41,8 +42,10 @@ const SyntaxHighlighter = (
     classes.push('CodeEditor');
   }
 
+  const wrapper = opts.inline ? 'span' : 'div';
+
   return React.createElement(
-    'div',
+    wrapper,
     { className: classes.join(' ') },
     codemirror(typeof code === 'string' ? code : '', lang, opts)
   );


### PR DESCRIPTION
See: [@readme/markdown#140][140]
:---:

## 🧰 What's being changed?

If you write a code block, the RDMD engine will wrap the code contents with a `div`. Unfortunately, this holds true for *inline* code snippets as well, since they're represented by the same underlying MDAST. [Per the W3][w3], `<p>` tags may *only* contain other inline elements, which means the engine throws a warning whenever we render an inline code snippet within a paragraph. Which is, like, all the time...

- [x] Add an `inline` option to toggle the wrapper tag between `div` and `span`.
- [x] Add docs + update some markdown.

## 🧪 Testing

Check out [@readme/markdown#140][140] for the integration piece of this puzzle.

[w3]: https://www.w3.org/TR/html401/struct/text.html#h-9.3.1
[140]: https://github.com/readmeio/markdown/pull/140