### PR TITLE
feat: enable code folding

### DIFF
--- a/__tests__/__snapshots__/codeMirror.test.js.snap
+++ b/__tests__/__snapshots__/codeMirror.test.js.snap
@@ -347,6 +347,22 @@ exports[`Supported languages cURL should syntax highlight an example 1`] = `
 </div>"
 `;
 
+exports[`code folding relevant options in the props matches snapshot 1`] = `
+Object {
+  "editable": true,
+  "foldGutter": true,
+  "gutters": Array [
+    "CodeMirror-linenumbers",
+    "CodeMirror-foldgutter",
+  ],
+  "lineNumbers": true,
+  "mode": "application/ld+json",
+  "readOnly": true,
+  "tabSize": 2,
+  "theme": "neo",
+}
+`;
+
 exports[`should tokenize variables outside of quotes over multiple lines 1`] = `
 "
   const foo = APIKEY;

--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -229,3 +229,29 @@ describe('runmode', () => {
     expect(checkLineBreaks).toStrictEqual(totalLines.length);
   });
 });
+
+describe('code folding', () => {
+  beforeAll(() => {
+    // Prevents tests from throwing `TypeError: range(...).getBoundingClientRect is not a function`
+    // Ref: https://github.com/jsdom/jsdom/issues/3002
+    document.createRange = () => {
+      const range = new Range();
+
+      range.getBoundingClientRect = jest.fn();
+
+      range.getClientRects = jest.fn(() => ({
+        item: () => null,
+        length: 0,
+      }));
+
+      return range;
+    };
+  });
+
+  it('relevant options in the props matches snapshot', () => {
+    const { options } = shallow(
+      syntaxHighlighter('{ "a": { "b": { "c": 1 } }', 'json', { foldGutter: true, readOnly: true })
+    ).props();
+    expect(options).toMatchSnapshot();
+  });
+});

--- a/public/index.js
+++ b/public/index.js
@@ -7,6 +7,32 @@ const exampleCode = `curl --request POST
   --header 'authorization: Bearer 123'
   --header 'content-type: application/json'`;
 
+const exampleJson = `{
+    "key": "value",
+    "array": [1, 2, 3],
+    "a": {
+      "b": {
+        "c": {
+          "d": "ok",
+          "e": "err"
+        },
+        "f": {
+          "g": "ok"
+        },
+        "h": {
+          "i": "ok"
+        }
+      },
+      "j": {
+        "k": {
+          "l": "ok"
+        }
+      }
+    },
+    "isThing": true
+  }
+  `;
+
 ReactDOM.render(
   <div>
     <h1>Core Syntax Highlighter</h1>
@@ -115,6 +141,23 @@ ReactDOM.render(
     <h2>Custom Theme: tomorrow-night</h2>
     <pre id="hub-reference">
       {syntaxHighlighter(exampleCode, 'curl', { editable: true, customTheme: 'tomorrow-night' })}
+    </pre>
+
+    <hr />
+    <h1>Code Folding</h1>
+    <h2>Dark Theme</h2>
+    <pre id="hub-reference">
+      {syntaxHighlighter(exampleJson, 'json', { foldGutter: true, readOnly: true, dark: true })}
+    </pre>
+
+    <h2>Light Theme</h2>
+    <pre id="hub-reference">
+      {syntaxHighlighter(exampleJson, 'json', { foldGutter: true, readOnly: true, dark: false })}
+    </pre>
+
+    <h2>Custom Theme: tomorrow-night</h2>
+    <pre id="hub-reference">
+      {syntaxHighlighter(exampleJson, 'json', { foldGutter: true, readOnly: true, customTheme: 'tomorrow-night' })}
     </pre>
   </div>,
   document.getElementById('root')

--- a/src/codeEditor/style.scss
+++ b/src/codeEditor/style.scss
@@ -2,4 +2,5 @@
   @import '~codemirror/lib/codemirror.css';
   @import '~codemirror/theme/material-palenight.css';
   @import '~codemirror/theme/neo.css';
+  @import '~codemirror/addon/fold/foldgutter.css';
 }

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -6,6 +6,8 @@ import { getMode } from '../utils/modes';
 
 import '../utils/cm-mode-imports';
 import './style.scss';
+import 'codemirror/addon/fold/brace-fold';
+import 'codemirror/addon/fold/foldgutter';
 import 'codemirror/addon/runmode/runmode';
 import 'codemirror/mode/meta';
 

--- a/src/index.js
+++ b/src/index.js
@@ -24,12 +24,21 @@ const SyntaxHighlighter = (
     theme = opts.customTheme;
   }
 
+  if (opts.foldGutter) {
+    // `foldGutter` does not work with runmode and has to be done with the codeEditor component
+    // NOTE: To disable editing, to still allow folding, `readOnly` must be `true`.
+    opts.editable = true;
+    // Default CSS classes
+    opts.gutters = ['CodeMirror-linenumbers', 'CodeMirror-foldgutter'];
+  }
+
   if (opts.editable) {
     return React.createElement(codeEditor, {
       ...editorProps,
       code,
       lang,
       theme,
+      options: opts,
     });
   }
 


### PR DESCRIPTION
## 🧰 What's being changed?

This enables the user to pass `foldGutter: true` into the options for the `syntaxHighlighter` which will return a component that support code folding that uses the same CodeMirror add-on as is show in this [demo](https://codemirror.net/demo/folding.html).

## 🧪 Testing

This change can be tested on `http://localhost:3400/`, here is a screen recording:

https://user-images.githubusercontent.com/4505008/113056084-59e23780-9179-11eb-8d1a-1d3ec39d4d71.mov


