### PR TITLE
fix: pinning codemirror to 5.54.0

### DIFF
--- a/__tests__/__snapshots__/codeMirror.test.js.snap
+++ b/__tests__/__snapshots__/codeMirror.test.js.snap
@@ -202,7 +202,7 @@ exports[`Supported languages JavaScript should syntax highlight an example 1`] =
 `;
 
 exports[`Supported languages Julia should syntax highlight an example 1`] = `
-"<div class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
+"<div class=\\"cm-s-neo\\"><span class=\\"cm-builtin\\">println</span>(<span class=\\"cm-string\\">&quot;Hello World&quot;</span>)
 </div>"
 `;
 
@@ -345,7 +345,7 @@ exports[`Supported languages Shell should syntax highlight an example 1`] = `
 `;
 
 exports[`Supported languages Solidity should syntax highlight an example 1`] = `
-"<div class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">pragma</span> <span class=\\"cm-variable\\">solidity</span> <span class=\\"cm-variable\\">^0</span><span class=\\"cm-number\\">.8.9</span>;
+"<div class=\\"cm-s-neo\\"><span class=\\"cm-variable\\">pragma</span> <span class=\\"cm-variable\\">solidity</span> <span class=\\"cm-variable\\">^0</span>.<span class=\\"cm-number\\">8.9</span>;
 
 <span class=\\"cm-variable\\">contract</span> <span class=\\"cm-variable\\">HelloWorld</span> {
     <span class=\\"cm-variable\\">function</span> <span class=\\"cm-variable\\">render</span> () <span class=\\"cm-variable\\">public</span> <span class=\\"cm-variable\\">pure</span> <span class=\\"cm-variable\\">returns</span> (<span class=\\"cm-variable\\">string</span> <span class=\\"cm-variable\\">memory</span>) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,8 @@
       "version": "10.14.0",
       "license": "ISC",
       "dependencies": {
-        "codemirror": "^5.48.2",
-        "codemirror-graphql": "^1.0.2",
+        "codemirror": "5.54.0",
+        "codemirror-graphql": "1.0.2",
         "prop-types": "^15.7.2",
         "react-codemirror2": "^7.2.1"
       },
@@ -1834,77 +1834,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "node_modules/@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "dependencies": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "node_modules/@codemirror/language": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.6.tgz",
-      "integrity": "sha512-or5TU/bxhsQdhXT70SK/h9V/gX/rElDEQyG29VbEDnHZ8TaDo3xsX900EYP02/tpIj8sConefmuMQfrePr+OCA==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/rangeset": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
-      "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
-      "dependencies": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
-      "dependencies": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "node_modules/@codemirror/stream-parser": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.2.tgz",
-      "integrity": "sha512-hBKRQlyu8GUOrY33xZ6/1kAfNZ8ZUm6cX9a7mPx8zAAqnpz/fpksC/qJRrkg1mPMBwxm+JG4fqAwDGJ3gLVniQ==",
-      "dependencies": {
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/lr": "^0.15.0"
-      }
-    },
-    "node_modules/@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
-    },
-    "node_modules/@codemirror/view": {
-      "version": "0.19.24",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.24.tgz",
-      "integrity": "sha512-sAWBsJK0JWka+8xgkPqCefDTUZUEcyzXixoqnHG5V81o9owL1dKAWZ+VGcJP7CvAC3L4c2BMJyQu//WMIt2kdA==",
-      "dependencies": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
     "node_modules/@commitlint/cli": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
@@ -2362,13 +2291,13 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@graphql-tools/delegate": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.2.tgz",
-      "integrity": "sha512-CjggOhiL4WtyG2I3kux+1/p8lQxSFHBj0gwa0NxnQ6Vsnpw7Ig5VP1ovPnitFuBv2k4QdC37Nj2xv2n7DRn8fw==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
+      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
       "dependencies": {
         "@graphql-tools/batch-execute": "^8.3.1",
         "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/utils": "^8.5.4",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
@@ -2403,11 +2332,11 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@graphql-tools/import": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.1.tgz",
-      "integrity": "sha512-i9WA6k+erJMci822o9w9DoX+uncVBK60LGGYW8mdbhX0l7wEubUpA000thJ1aarCusYh0u+ZT9qX0HyVPXu25Q==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.2.tgz",
+      "integrity": "sha512-XBAw4GBaTwwA736VPTe5vKOS/FCVXpi0ofSeOa2AKedD4JEViAYx4Al3MPpmi2sIVumIOV7wGwHgX7HAgG5RdQ==",
       "dependencies": {
-        "@graphql-tools/utils": "8.5.3",
+        "@graphql-tools/utils": "8.5.4",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -2517,32 +2446,72 @@
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw=="
     },
     "node_modules/@graphql-tools/url-loader": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.3.tgz",
-      "integrity": "sha512-VKMRJ4TOeVIdulkCLGSBUr4stRRwOGcVRXDeoUF+86K32Ufo0H2V0lz7QwS/bCl8GXV19FMgHZCDl4BMJyOXEA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.0.tgz",
+      "integrity": "sha512-mBBb+aJqI4E0MVEzyfi76Pi/G6lGxGTVt/tP1YtKJly7UnonNoWOtDusdL3zIVAGhGgLsNrLbGhLDbwSd6TV6A==",
       "dependencies": {
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
-        "@n1ru4l/graphql-live-query": "0.9.0",
-        "@types/websocket": "1.0.4",
+        "@n1ru4l/graphql-live-query": "^0.9.0",
+        "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.0.26",
+        "cross-undici-fetch": "^0.1.4",
         "dset": "^3.1.0",
-        "extract-files": "11.0.0",
+        "extract-files": "^11.0.0",
         "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
-        "isomorphic-ws": "4.0.1",
-        "meros": "1.1.4",
+        "isomorphic-ws": "^4.0.1",
+        "meros": "^1.1.4",
         "subscriptions-transport-ws": "^0.11.0",
-        "sync-fetch": "0.3.1",
-        "tslib": "~2.3.0",
-        "valid-url": "1.0.9",
-        "value-or-promise": "1.0.11",
-        "ws": "8.3.0"
+        "sync-fetch": "^0.3.1",
+        "tslib": "^2.3.0",
+        "valid-url": "^1.0.9",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.3.0"
       },
       "peerDependencies": {
         "graphql": "^14.0.0 || ^15.0.0 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/eventemitter3": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/subscriptions-transport-ws": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+      "dependencies": {
+        "backo2": "^1.0.2",
+        "eventemitter3": "^3.1.0",
+        "iterall": "^1.2.1",
+        "symbol-observable": "^1.0.4",
+        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+      },
+      "peerDependencies": {
+        "graphql": "^15.7.2 || ^16.0.0"
+      }
+    },
+    "node_modules/@graphql-tools/url-loader/node_modules/subscriptions-transport-ws/node_modules/ws": {
+      "version": "7.5.6",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+      "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+      "engines": {
+        "node": ">=8.3.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": "^5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/@graphql-tools/url-loader/node_modules/tslib": {
@@ -2571,9 +2540,9 @@
       }
     },
     "node_modules/@graphql-tools/utils": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.3.tgz",
-      "integrity": "sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.4.tgz",
+      "integrity": "sha512-ViupMJH590be75tCiyHs/wgJ2KPbWMzc+jopen6P6MliHWoqRlGWMMvYQE1hDj25v4fxObCVq20maQCow0T9nQ==",
       "dependencies": {
         "tslib": "~2.3.0"
       },
@@ -2914,19 +2883,6 @@
         "@types/yargs-parser": "*"
       }
     },
-    "node_modules/@lezer/common": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.10.tgz",
-      "integrity": "sha512-vlr+be73zTDoQBIknBVOh/633tmbQcjxUu9PIeVeYESeBK3V6TuBW96RRFg93Y2cyK9lglz241gOgSn452HFvA=="
-    },
-    "node_modules/@lezer/lr": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.5.tgz",
-      "integrity": "sha512-DEcLyhdmBxD1foQe7RegLrSlfS/XaTMGLkO5evkzHWAQKh/JnFWp7j7iNB7s2EpxzRrBCh0U+W7JDCeFhv2mng==",
-      "dependencies": {
-        "@lezer/common": "^0.15.0"
-      }
-    },
     "node_modules/@n1ru4l/graphql-live-query": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz",
@@ -3194,8 +3150,7 @@
     "node_modules/@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "node_modules/@types/json5": {
       "version": "0.0.29",
@@ -3252,9 +3207,9 @@
       }
     },
     "node_modules/@types/ws": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
-      "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
       "dependencies": {
         "@types/node": "*"
       }
@@ -4143,7 +4098,8 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "node_modules/aws-sign2": {
       "version": "0.7.0",
@@ -4873,21 +4829,21 @@
       }
     },
     "node_modules/codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
+      "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
     },
     "node_modules/codemirror-graphql": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.2.5.tgz",
-      "integrity": "sha512-5u+8OAxm72t0qtTYM9q+JLbhETmkbRVQ42HbDRW9MqGQtrlEAKs8pmQo1R9v25BopT9vmud05sP3JwqB4oqjgQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.0.2.tgz",
+      "integrity": "sha512-D4+BdYa6iQnDlio4mBk1Yap5ROCqEWapSFLkiKGatx/I0dF6euzdwd0um3Ndudw6rFQbNuT7hpcH8tnBO6VOfQ==",
       "dependencies": {
-        "@codemirror/stream-parser": "^0.19.2",
-        "graphql-language-service": "^3.2.5"
+        "graphql-language-service-interface": "^2.8.2",
+        "graphql-language-service-parser": "^1.9.0"
       },
       "peerDependencies": {
-        "codemirror": "^5.58.2",
-        "graphql": "^15.5.0 || ^16.0.0"
+        "codemirror": "^5.54.0",
+        "graphql": ">= v14.5.0 <= 15.5.0"
       }
     },
     "node_modules/collect-v8-coverage": {
@@ -4919,6 +4875,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -5207,27 +5164,15 @@
       }
     },
     "node_modules/cross-undici-fetch": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.26.tgz",
-      "integrity": "sha512-aMDRrLbWr0TGXfY92stlV+XOGpskeqFmWmrKSWsnc8w6gK5LPE83NBh7O7N6gCb2xjwHcm1Yn2nBXMEVH2RBcA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.4.tgz",
+      "integrity": "sha512-jIcyxjQ6mEvUS3y2yhIVktOR7wlGZuyjFAK8woo7pMb+BR1f2ylfTxsN01UPwhqT8gtYPmZ2rPdyoInr1Cdrrw==",
       "dependencies": {
         "abort-controller": "^3.0.0",
-        "form-data": "^4.0.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.5",
         "undici": "^4.9.3"
-      }
-    },
-    "node_modules/cross-undici-fetch/node_modules/form-data": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.8",
-        "mime-types": "^2.1.12"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/css-loader": {
@@ -5528,6 +5473,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -7469,6 +7415,23 @@
         "node": ">= 0.12"
       }
     },
+    "node_modules/form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
+    "node_modules/formdata-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.1.tgz",
+      "integrity": "sha512-8xKSa9et4zb+yziWsD/bI+EYjdg1z2p9EpKr+o+Yk12F/wP66bmDdvjj2ZXd2K/MJlR3HBzWnuV7f82jzHRqCA==",
+      "dependencies": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.1"
+      },
+      "engines": {
+        "node": ">= 12.20"
+      }
+    },
     "node_modules/forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -7877,12 +7840,12 @@
       "dev": true
     },
     "node_modules/graphql": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.0.1.tgz",
-      "integrity": "sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
       "peer": true,
       "engines": {
-        "node": "^12.22.0 || ^14.16.0 || >=16.0.0"
+        "node": ">= 10.x"
       }
     },
     "node_modules/graphql-config": {
@@ -7909,32 +7872,15 @@
         "graphql": "^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0"
       }
     },
-    "node_modules/graphql-language-service": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-3.2.5.tgz",
-      "integrity": "sha512-utkQ8GfYrR310E7AWk2dGE9QRidIEtAJPJ5j0THHlA+h12s4loZmmGosaHpjzbKy6WCNKNw8aKkqt3eEBxJJRg==",
-      "dependencies": {
-        "graphql-language-service-interface": "^2.9.5",
-        "graphql-language-service-parser": "^1.10.3",
-        "graphql-language-service-types": "^1.8.6",
-        "graphql-language-service-utils": "^2.6.3"
-      },
-      "bin": {
-        "graphql": "dist/temp-bin.js"
-      },
-      "peerDependencies": {
-        "graphql": "^15.5.0 || ^16.0.0"
-      }
-    },
     "node_modules/graphql-language-service-interface": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.9.5.tgz",
-      "integrity": "sha512-ZZOflhzCgVBjnOInYlX2cB25zY9o+VY+0zMkDyEYY1i/nacSlXiBRa7/v+0evsYiGIxx4WvkPwFgfjhFtLQS9A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.10.2.tgz",
+      "integrity": "sha512-RKIEBPhRMWdXY3fxRs99XysTDnEgAvNbu8ov/5iOlnkZsWQNzitjtd0O0l1CutQOQt3iXoHde7w8uhCnKL4tcg==",
       "dependencies": {
         "graphql-config": "^4.1.0",
-        "graphql-language-service-parser": "^1.10.3",
-        "graphql-language-service-types": "^1.8.6",
-        "graphql-language-service-utils": "^2.6.3",
+        "graphql-language-service-parser": "^1.10.4",
+        "graphql-language-service-types": "^1.8.7",
+        "graphql-language-service-utils": "^2.7.1",
         "vscode-languageserver-types": "^3.15.1"
       },
       "peerDependencies": {
@@ -7942,33 +7888,35 @@
       }
     },
     "node_modules/graphql-language-service-parser": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.10.3.tgz",
-      "integrity": "sha512-vGHf7g4zxwIt2RxJI0YKkN5Zhjp3s4RmqRij2FS96K08V8lzPvGcaDRcr8Bzoeb20YZPwPAidZjSt/yYqzyX1w==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.10.4.tgz",
+      "integrity": "sha512-duDE+0aeKLFVrb9Kf28U84ZEHhHcvTjWIT6dJbIAQJWBaDoht0D4BK9EIhd94I3DtKRc1JCJb2+70y1lvP/hiA==",
       "dependencies": {
-        "graphql-language-service-types": "^1.8.6"
+        "graphql-language-service-types": "^1.8.7"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-language-service-types": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.6.tgz",
-      "integrity": "sha512-1xH2kqkgKjvfsc/+fyDnzP21aSSofbVYfzyH8QcNCsxVF0zEvUij+3qyO/dHmQljIyc+Ss62J2udlnZEZM0hcA==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.7.tgz",
+      "integrity": "sha512-LP/Mx0nFBshYEyD0Ny6EVGfacJAGVx+qXtlJP4hLzUdBNOGimfDNtMVIdZANBXHXcM41MDgMHTnyEx2g6/Ttbw==",
       "dependencies": {
-        "graphql-config": "^4.1.0"
+        "graphql-config": "^4.1.0",
+        "vscode-languageserver-types": "^3.15.1"
       },
       "peerDependencies": {
         "graphql": "^15.5.0 || ^16.0.0"
       }
     },
     "node_modules/graphql-language-service-utils": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.6.3.tgz",
-      "integrity": "sha512-rc5SToegDZ3VlnC0J7EriWe3G9zxFsPspxNV/rqcMcMq2hON9Q53bxTdg75KTNRUY78h+1ZHsXPEgecQtVk+0w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.7.1.tgz",
+      "integrity": "sha512-Wci5MbrQj+6d7rfvbORrA9uDlfMysBWYaG49ST5TKylNaXYFf3ixFOa74iM1KtM9eidosUbI3E1JlWi0JaidJA==",
       "dependencies": {
-        "graphql-language-service-types": "^1.8.6",
+        "@types/json-schema": "7.0.9",
+        "graphql-language-service-types": "^1.8.7",
         "nullthrows": "^1.0.0"
       },
       "peerDependencies": {
@@ -10731,6 +10679,7 @@
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
       "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -10739,6 +10688,7 @@
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.49.0"
       },
@@ -10948,6 +10898,24 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
       "integrity": "sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==",
       "dev": true
+    },
+    "node_modules/node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/jimmywarting"
+        },
+        {
+          "type": "github",
+          "url": "https://paypal.me/jimmywarting"
+        }
+      ],
+      "engines": {
+        "node": ">=10.5.0"
+      }
     },
     "node_modules/node-fetch": {
       "version": "2.6.6",
@@ -13690,31 +13658,6 @@
         "webpack": "^5.0.0"
       }
     },
-    "node_modules/style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
-    },
-    "node_modules/subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "dependencies": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "peerDependencies": {
-        "graphql": "^15.7.2 || ^16.0.0"
-      }
-    },
-    "node_modules/subscriptions-transport-ws/node_modules/eventemitter3": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-      "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-    },
     "node_modules/supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -14225,9 +14168,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.10.3.tgz",
-      "integrity": "sha512-oMfhoSsFdu7ft+10gBpQ98gfIGT6qovXXRxYPOe07xfUJwpVTcFs0xvuAEpNqtObhf4HQWuMW5kWzaD768YS4Q==",
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.11.3.tgz",
+      "integrity": "sha512-bLOCH2juB9gAkqE4a4zb+eMGhI8XD4SH1tF9Qu9J3Y8TA379Xxg7lWRMiDvc36pRWV1z9/HICv05fXkeeLw1Dg==",
       "engines": {
         "node": ">=12.18"
       }
@@ -14447,11 +14390,6 @@
         "browser-process-hrtime": "^1.0.0"
       }
     },
-    "node_modules/w3c-keyname": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
-    },
     "node_modules/w3c-xmlserializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
@@ -14493,6 +14431,14 @@
       "dev": true,
       "dependencies": {
         "minimalistic-assert": "^1.0.0"
+      }
+    },
+    "node_modules/web-streams-polyfill": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ==",
+      "engines": {
+        "node": ">= 12"
       }
     },
     "node_modules/webidl-conversions": {
@@ -16469,77 +16415,6 @@
       "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
       "dev": true
     },
-    "@codemirror/highlight": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/highlight/-/highlight-0.19.6.tgz",
-      "integrity": "sha512-+eibu6on9quY8uN3xJ/n3rH+YIDLlpX7YulVmFvqAIz/ukRQ5tWaBmB7fMixHmnmRIRBRZgB8rNtonuMwZSAHQ==",
-      "requires": {
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "style-mod": "^4.0.0"
-      }
-    },
-    "@codemirror/language": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-0.19.6.tgz",
-      "integrity": "sha512-or5TU/bxhsQdhXT70SK/h9V/gX/rElDEQyG29VbEDnHZ8TaDo3xsX900EYP02/tpIj8sConefmuMQfrePr+OCA==",
-      "requires": {
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@codemirror/view": "^0.19.0",
-        "@lezer/common": "^0.15.5",
-        "@lezer/lr": "^0.15.0"
-      }
-    },
-    "@codemirror/rangeset": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/rangeset/-/rangeset-0.19.2.tgz",
-      "integrity": "sha512-5d+X8LtmeZtfFtKrSx57bIHRUpKv2HD0b74clp4fGA7qJLLfYehF6FGkJJxJb8lKsqAga1gdjjWr0jiypmIxoQ==",
-      "requires": {
-        "@codemirror/state": "^0.19.0"
-      }
-    },
-    "@codemirror/state": {
-      "version": "0.19.6",
-      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-0.19.6.tgz",
-      "integrity": "sha512-sqIQZE9VqwQj7D4c2oz9mfLhlT1ElAzGB5lO1lE33BPyrdNy1cJyCIOecT4cn4VeJOFrnjOeu+IftZ3zqdFETw==",
-      "requires": {
-        "@codemirror/text": "^0.19.0"
-      }
-    },
-    "@codemirror/stream-parser": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@codemirror/stream-parser/-/stream-parser-0.19.2.tgz",
-      "integrity": "sha512-hBKRQlyu8GUOrY33xZ6/1kAfNZ8ZUm6cX9a7mPx8zAAqnpz/fpksC/qJRrkg1mPMBwxm+JG4fqAwDGJ3gLVniQ==",
-      "requires": {
-        "@codemirror/highlight": "^0.19.0",
-        "@codemirror/language": "^0.19.0",
-        "@codemirror/state": "^0.19.0",
-        "@codemirror/text": "^0.19.0",
-        "@lezer/common": "^0.15.0",
-        "@lezer/lr": "^0.15.0"
-      }
-    },
-    "@codemirror/text": {
-      "version": "0.19.5",
-      "resolved": "https://registry.npmjs.org/@codemirror/text/-/text-0.19.5.tgz",
-      "integrity": "sha512-Syu5Xc7tZzeUAM/y4fETkT0zgGr48rDG+w4U38bPwSIUr+L9S/7w2wDE1WGNzjaZPz12F6gb1gxWiSTg9ocLow=="
-    },
-    "@codemirror/view": {
-      "version": "0.19.24",
-      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-0.19.24.tgz",
-      "integrity": "sha512-sAWBsJK0JWka+8xgkPqCefDTUZUEcyzXixoqnHG5V81o9owL1dKAWZ+VGcJP7CvAC3L4c2BMJyQu//WMIt2kdA==",
-      "requires": {
-        "@codemirror/rangeset": "^0.19.0",
-        "@codemirror/state": "^0.19.3",
-        "@codemirror/text": "^0.19.0",
-        "style-mod": "^4.0.0",
-        "w3c-keyname": "^2.2.4"
-      }
-    },
     "@commitlint/cli": {
       "version": "15.0.0",
       "resolved": "https://registry.npmjs.org/@commitlint/cli/-/cli-15.0.0.tgz",
@@ -16887,13 +16762,13 @@
       }
     },
     "@graphql-tools/delegate": {
-      "version": "8.4.2",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.2.tgz",
-      "integrity": "sha512-CjggOhiL4WtyG2I3kux+1/p8lQxSFHBj0gwa0NxnQ6Vsnpw7Ig5VP1ovPnitFuBv2k4QdC37Nj2xv2n7DRn8fw==",
+      "version": "8.4.3",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/delegate/-/delegate-8.4.3.tgz",
+      "integrity": "sha512-hKTJdJXJnKL0+2vpU+Kt7OHQTIXZ9mBmNBwHsYiG5WNArz/vNI7910r6TC2XMf/e7zhyyK+mXxMDBmDQkkJagA==",
       "requires": {
         "@graphql-tools/batch-execute": "^8.3.1",
         "@graphql-tools/schema": "^8.3.1",
-        "@graphql-tools/utils": "^8.5.3",
+        "@graphql-tools/utils": "^8.5.4",
         "dataloader": "2.0.0",
         "tslib": "~2.3.0",
         "value-or-promise": "1.0.11"
@@ -16926,11 +16801,11 @@
       }
     },
     "@graphql-tools/import": {
-      "version": "6.6.1",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.1.tgz",
-      "integrity": "sha512-i9WA6k+erJMci822o9w9DoX+uncVBK60LGGYW8mdbhX0l7wEubUpA000thJ1aarCusYh0u+ZT9qX0HyVPXu25Q==",
+      "version": "6.6.2",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/import/-/import-6.6.2.tgz",
+      "integrity": "sha512-XBAw4GBaTwwA736VPTe5vKOS/FCVXpi0ofSeOa2AKedD4JEViAYx4Al3MPpmi2sIVumIOV7wGwHgX7HAgG5RdQ==",
       "requires": {
-        "@graphql-tools/utils": "8.5.3",
+        "@graphql-tools/utils": "8.5.4",
         "resolve-from": "5.0.0",
         "tslib": "~2.3.0"
       },
@@ -17026,31 +16901,56 @@
       }
     },
     "@graphql-tools/url-loader": {
-      "version": "7.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.5.3.tgz",
-      "integrity": "sha512-VKMRJ4TOeVIdulkCLGSBUr4stRRwOGcVRXDeoUF+86K32Ufo0H2V0lz7QwS/bCl8GXV19FMgHZCDl4BMJyOXEA==",
+      "version": "7.7.0",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/url-loader/-/url-loader-7.7.0.tgz",
+      "integrity": "sha512-mBBb+aJqI4E0MVEzyfi76Pi/G6lGxGTVt/tP1YtKJly7UnonNoWOtDusdL3zIVAGhGgLsNrLbGhLDbwSd6TV6A==",
       "requires": {
         "@graphql-tools/delegate": "^8.4.1",
         "@graphql-tools/utils": "^8.5.1",
         "@graphql-tools/wrap": "^8.3.1",
-        "@n1ru4l/graphql-live-query": "0.9.0",
-        "@types/websocket": "1.0.4",
+        "@n1ru4l/graphql-live-query": "^0.9.0",
+        "@types/websocket": "^1.0.4",
         "@types/ws": "^8.0.0",
-        "cross-undici-fetch": "^0.0.26",
+        "cross-undici-fetch": "^0.1.4",
         "dset": "^3.1.0",
-        "extract-files": "11.0.0",
+        "extract-files": "^11.0.0",
         "graphql-sse": "^1.0.1",
         "graphql-ws": "^5.4.1",
-        "isomorphic-ws": "4.0.1",
-        "meros": "1.1.4",
+        "isomorphic-ws": "^4.0.1",
+        "meros": "^1.1.4",
         "subscriptions-transport-ws": "^0.11.0",
-        "sync-fetch": "0.3.1",
-        "tslib": "~2.3.0",
-        "valid-url": "1.0.9",
-        "value-or-promise": "1.0.11",
-        "ws": "8.3.0"
+        "sync-fetch": "^0.3.1",
+        "tslib": "^2.3.0",
+        "valid-url": "^1.0.9",
+        "value-or-promise": "^1.0.11",
+        "ws": "^8.3.0"
       },
       "dependencies": {
+        "eventemitter3": {
+          "version": "3.1.2",
+          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
+          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
+        },
+        "subscriptions-transport-ws": {
+          "version": "0.11.0",
+          "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
+          "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
+          "requires": {
+            "backo2": "^1.0.2",
+            "eventemitter3": "^3.1.0",
+            "iterall": "^1.2.1",
+            "symbol-observable": "^1.0.4",
+            "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
+          },
+          "dependencies": {
+            "ws": {
+              "version": "7.5.6",
+              "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.6.tgz",
+              "integrity": "sha512-6GLgCqo2cy2A2rjCNFlxQS6ZljG/coZfZXclldI8FB/1G3CCI36Zd8xy2HrFVACi8tfk5XrgLQEk+P0Tnz9UcA==",
+              "requires": {}
+            }
+          }
+        },
         "tslib": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.3.1.tgz",
@@ -17065,9 +16965,9 @@
       }
     },
     "@graphql-tools/utils": {
-      "version": "8.5.3",
-      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.3.tgz",
-      "integrity": "sha512-HDNGWFVa8QQkoQB0H1lftvaO1X5xUaUDk1zr1qDe0xN1NL0E/CrQdJ5UKLqOvH4hkqVUPxQsyOoAZFkaH6rLHg==",
+      "version": "8.5.4",
+      "resolved": "https://registry.npmjs.org/@graphql-tools/utils/-/utils-8.5.4.tgz",
+      "integrity": "sha512-ViupMJH590be75tCiyHs/wgJ2KPbWMzc+jopen6P6MliHWoqRlGWMMvYQE1hDj25v4fxObCVq20maQCow0T9nQ==",
       "requires": {
         "tslib": "~2.3.0"
       },
@@ -17349,19 +17249,6 @@
         }
       }
     },
-    "@lezer/common": {
-      "version": "0.15.10",
-      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-0.15.10.tgz",
-      "integrity": "sha512-vlr+be73zTDoQBIknBVOh/633tmbQcjxUu9PIeVeYESeBK3V6TuBW96RRFg93Y2cyK9lglz241gOgSn452HFvA=="
-    },
-    "@lezer/lr": {
-      "version": "0.15.5",
-      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-0.15.5.tgz",
-      "integrity": "sha512-DEcLyhdmBxD1foQe7RegLrSlfS/XaTMGLkO5evkzHWAQKh/JnFWp7j7iNB7s2EpxzRrBCh0U+W7JDCeFhv2mng==",
-      "requires": {
-        "@lezer/common": "^0.15.0"
-      }
-    },
     "@n1ru4l/graphql-live-query": {
       "version": "0.9.0",
       "resolved": "https://registry.npmjs.org/@n1ru4l/graphql-live-query/-/graphql-live-query-0.9.0.tgz",
@@ -17597,8 +17484,7 @@
     "@types/json-schema": {
       "version": "7.0.9",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.9.tgz",
-      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==",
-      "dev": true
+      "integrity": "sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ=="
     },
     "@types/json5": {
       "version": "0.0.29",
@@ -17655,9 +17541,9 @@
       }
     },
     "@types/ws": {
-      "version": "8.2.1",
-      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.1.tgz",
-      "integrity": "sha512-SqQ+LhVZaJi7c7sYVkjWALDigi/Wy7h7Iu72gkQp8Y8OWw/DddEVBrTSKu86pQftV2+Gm8lYM61hadPKqyaIeg==",
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-8.2.2.tgz",
+      "integrity": "sha512-NOn5eIcgWLOo6qW8AcuLZ7G8PycXu0xTxxkS6Q18VWFxgPUSOwV0pBj2a/4viNZVu25i7RIB7GttdkAIUUXOOg==",
       "requires": {
         "@types/node": "*"
       }
@@ -18343,7 +18229,8 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+      "dev": true
     },
     "aws-sign2": {
       "version": "0.7.0",
@@ -18911,17 +18798,17 @@
       "dev": true
     },
     "codemirror": {
-      "version": "5.64.0",
-      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.64.0.tgz",
-      "integrity": "sha512-fqr6CtDQdJ6iNMbD8NX2gH2G876nNDk+TO1rrYkgWnqQdO3O1Xa9tK6q+psqhJJgE5SpbaDcgdfLmukoUVE8pg=="
+      "version": "5.54.0",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-5.54.0.tgz",
+      "integrity": "sha512-Pgf3surv4zvw+KaW3doUU7pGjF0BPU8/sj7eglWJjzni46U/DDW8pu3nZY0QgQKUcICDXRkq8jZmq0y6KhxM3Q=="
     },
     "codemirror-graphql": {
-      "version": "1.2.5",
-      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.2.5.tgz",
-      "integrity": "sha512-5u+8OAxm72t0qtTYM9q+JLbhETmkbRVQ42HbDRW9MqGQtrlEAKs8pmQo1R9v25BopT9vmud05sP3JwqB4oqjgQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror-graphql/-/codemirror-graphql-1.0.2.tgz",
+      "integrity": "sha512-D4+BdYa6iQnDlio4mBk1Yap5ROCqEWapSFLkiKGatx/I0dF6euzdwd0um3Ndudw6rFQbNuT7hpcH8tnBO6VOfQ==",
       "requires": {
-        "@codemirror/stream-parser": "^0.19.2",
-        "graphql-language-service": "^3.2.5"
+        "graphql-language-service-interface": "^2.8.2",
+        "graphql-language-service-parser": "^1.9.0"
       }
     },
     "collect-v8-coverage": {
@@ -18953,6 +18840,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -19188,26 +19076,15 @@
       }
     },
     "cross-undici-fetch": {
-      "version": "0.0.26",
-      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.0.26.tgz",
-      "integrity": "sha512-aMDRrLbWr0TGXfY92stlV+XOGpskeqFmWmrKSWsnc8w6gK5LPE83NBh7O7N6gCb2xjwHcm1Yn2nBXMEVH2RBcA==",
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/cross-undici-fetch/-/cross-undici-fetch-0.1.4.tgz",
+      "integrity": "sha512-jIcyxjQ6mEvUS3y2yhIVktOR7wlGZuyjFAK8woo7pMb+BR1f2ylfTxsN01UPwhqT8gtYPmZ2rPdyoInr1Cdrrw==",
       "requires": {
         "abort-controller": "^3.0.0",
-        "form-data": "^4.0.0",
+        "form-data-encoder": "^1.7.1",
+        "formdata-node": "^4.3.1",
         "node-fetch": "^2.6.5",
         "undici": "^4.9.3"
-      },
-      "dependencies": {
-        "form-data": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
-          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
-          "requires": {
-            "asynckit": "^0.4.0",
-            "combined-stream": "^1.0.8",
-            "mime-types": "^2.1.12"
-          }
-        }
       }
     },
     "css-loader": {
@@ -19443,7 +19320,8 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+      "dev": true
     },
     "delegates": {
       "version": "1.0.0",
@@ -20934,6 +20812,20 @@
         "mime-types": "^2.1.12"
       }
     },
+    "form-data-encoder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-1.7.1.tgz",
+      "integrity": "sha512-EFRDrsMm/kyqbTQocNvRXMLjc7Es2Vk+IQFx/YW7hkUH1eBl4J1fqiP34l74Yt0pFLCNpc06fkbVk00008mzjg=="
+    },
+    "formdata-node": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/formdata-node/-/formdata-node-4.3.1.tgz",
+      "integrity": "sha512-8xKSa9et4zb+yziWsD/bI+EYjdg1z2p9EpKr+o+Yk12F/wP66bmDdvjj2ZXd2K/MJlR3HBzWnuV7f82jzHRqCA==",
+      "requires": {
+        "node-domexception": "1.0.0",
+        "web-streams-polyfill": "4.0.0-beta.1"
+      }
+    },
     "forwarded": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
@@ -21240,9 +21132,9 @@
       "dev": true
     },
     "graphql": {
-      "version": "16.0.1",
-      "resolved": "https://registry.npmjs.org/graphql/-/graphql-16.0.1.tgz",
-      "integrity": "sha512-oPvCuu6dlLdiz8gZupJ47o1clgb72r1u8NDBcQYjcV6G/iEdmE11B1bBlkhXRvV0LisP/SXRFP7tT6AgaTjpzg==",
+      "version": "15.5.0",
+      "resolved": "https://registry.npmjs.org/graphql/-/graphql-15.5.0.tgz",
+      "integrity": "sha512-OmaM7y0kaK31NKG31q4YbD2beNYa6jBBKtMFT6gLYJljHLJr42IqJ8KX08u3Li/0ifzTU5HjmoOOrwa5BRLeDA==",
       "peer": true
     },
     "graphql-config": {
@@ -21263,51 +21155,42 @@
         "string-env-interpolation": "1.0.1"
       }
     },
-    "graphql-language-service": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/graphql-language-service/-/graphql-language-service-3.2.5.tgz",
-      "integrity": "sha512-utkQ8GfYrR310E7AWk2dGE9QRidIEtAJPJ5j0THHlA+h12s4loZmmGosaHpjzbKy6WCNKNw8aKkqt3eEBxJJRg==",
-      "requires": {
-        "graphql-language-service-interface": "^2.9.5",
-        "graphql-language-service-parser": "^1.10.3",
-        "graphql-language-service-types": "^1.8.6",
-        "graphql-language-service-utils": "^2.6.3"
-      }
-    },
     "graphql-language-service-interface": {
-      "version": "2.9.5",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.9.5.tgz",
-      "integrity": "sha512-ZZOflhzCgVBjnOInYlX2cB25zY9o+VY+0zMkDyEYY1i/nacSlXiBRa7/v+0evsYiGIxx4WvkPwFgfjhFtLQS9A==",
+      "version": "2.10.2",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-interface/-/graphql-language-service-interface-2.10.2.tgz",
+      "integrity": "sha512-RKIEBPhRMWdXY3fxRs99XysTDnEgAvNbu8ov/5iOlnkZsWQNzitjtd0O0l1CutQOQt3iXoHde7w8uhCnKL4tcg==",
       "requires": {
         "graphql-config": "^4.1.0",
-        "graphql-language-service-parser": "^1.10.3",
-        "graphql-language-service-types": "^1.8.6",
-        "graphql-language-service-utils": "^2.6.3",
+        "graphql-language-service-parser": "^1.10.4",
+        "graphql-language-service-types": "^1.8.7",
+        "graphql-language-service-utils": "^2.7.1",
         "vscode-languageserver-types": "^3.15.1"
       }
     },
     "graphql-language-service-parser": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.10.3.tgz",
-      "integrity": "sha512-vGHf7g4zxwIt2RxJI0YKkN5Zhjp3s4RmqRij2FS96K08V8lzPvGcaDRcr8Bzoeb20YZPwPAidZjSt/yYqzyX1w==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-parser/-/graphql-language-service-parser-1.10.4.tgz",
+      "integrity": "sha512-duDE+0aeKLFVrb9Kf28U84ZEHhHcvTjWIT6dJbIAQJWBaDoht0D4BK9EIhd94I3DtKRc1JCJb2+70y1lvP/hiA==",
       "requires": {
-        "graphql-language-service-types": "^1.8.6"
+        "graphql-language-service-types": "^1.8.7"
       }
     },
     "graphql-language-service-types": {
-      "version": "1.8.6",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.6.tgz",
-      "integrity": "sha512-1xH2kqkgKjvfsc/+fyDnzP21aSSofbVYfzyH8QcNCsxVF0zEvUij+3qyO/dHmQljIyc+Ss62J2udlnZEZM0hcA==",
+      "version": "1.8.7",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-types/-/graphql-language-service-types-1.8.7.tgz",
+      "integrity": "sha512-LP/Mx0nFBshYEyD0Ny6EVGfacJAGVx+qXtlJP4hLzUdBNOGimfDNtMVIdZANBXHXcM41MDgMHTnyEx2g6/Ttbw==",
       "requires": {
-        "graphql-config": "^4.1.0"
+        "graphql-config": "^4.1.0",
+        "vscode-languageserver-types": "^3.15.1"
       }
     },
     "graphql-language-service-utils": {
-      "version": "2.6.3",
-      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.6.3.tgz",
-      "integrity": "sha512-rc5SToegDZ3VlnC0J7EriWe3G9zxFsPspxNV/rqcMcMq2hON9Q53bxTdg75KTNRUY78h+1ZHsXPEgecQtVk+0w==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/graphql-language-service-utils/-/graphql-language-service-utils-2.7.1.tgz",
+      "integrity": "sha512-Wci5MbrQj+6d7rfvbORrA9uDlfMysBWYaG49ST5TKylNaXYFf3ixFOa74iM1KtM9eidosUbI3E1JlWi0JaidJA==",
       "requires": {
-        "graphql-language-service-types": "^1.8.6",
+        "@types/json-schema": "7.0.9",
+        "graphql-language-service-types": "^1.8.7",
         "nullthrows": "^1.0.0"
       }
     },
@@ -23432,12 +23315,14 @@
     "mime-db": {
       "version": "1.49.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.49.0.tgz",
-      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA=="
+      "integrity": "sha512-CIc8j9URtOVApSFCQIF+VBkX1RwXp/oMMOrqdyXSBXq5RWNEsRfyj1kiRnQgmNXmHxPoFIxOroKA3zcU9P+nAA==",
+      "dev": true
     },
     "mime-types": {
       "version": "2.1.32",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.32.tgz",
       "integrity": "sha512-hJGaVS4G4c9TSMYh2n6SQAGrC4RnfU+daP8G7cSCmaqNjiOoUY0VHCMS42pxnQmVF1GWwFhbHWn3RIxCqTmZ9A==",
+      "dev": true,
       "requires": {
         "mime-db": "1.49.0"
       }
@@ -23607,6 +23492,11 @@
           "dev": true
         }
       }
+    },
+    "node-domexception": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/node-domexception/-/node-domexception-1.0.0.tgz",
+      "integrity": "sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ=="
     },
     "node-fetch": {
       "version": "2.6.6",
@@ -25795,30 +25685,6 @@
       "dev": true,
       "requires": {}
     },
-    "style-mod": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.0.0.tgz",
-      "integrity": "sha512-OPhtyEjyyN9x3nhPsu76f52yUGXiZcgvsrFVtvTkyGRQJ0XK+GPc6ov1z+lRpbeabka+MYEQxOYRnt5nF30aMw=="
-    },
-    "subscriptions-transport-ws": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/subscriptions-transport-ws/-/subscriptions-transport-ws-0.11.0.tgz",
-      "integrity": "sha512-8D4C6DIH5tGiAIpp5I0wD/xRlNiZAPGHygzCe7VzyzUoxHtawzjNAY9SUTXU05/EY2NMY9/9GF0ycizkXr1CWQ==",
-      "requires": {
-        "backo2": "^1.0.2",
-        "eventemitter3": "^3.1.0",
-        "iterall": "^1.2.1",
-        "symbol-observable": "^1.0.4",
-        "ws": "^5.2.0 || ^6.0.0 || ^7.0.0"
-      },
-      "dependencies": {
-        "eventemitter3": {
-          "version": "3.1.2",
-          "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-3.1.2.tgz",
-          "integrity": "sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q=="
-        }
-      }
-    },
     "supports-color": {
       "version": "7.1.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
@@ -26200,9 +26066,9 @@
       }
     },
     "undici": {
-      "version": "4.10.3",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-4.10.3.tgz",
-      "integrity": "sha512-oMfhoSsFdu7ft+10gBpQ98gfIGT6qovXXRxYPOe07xfUJwpVTcFs0xvuAEpNqtObhf4HQWuMW5kWzaD768YS4Q=="
+      "version": "4.11.3",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-4.11.3.tgz",
+      "integrity": "sha512-bLOCH2juB9gAkqE4a4zb+eMGhI8XD4SH1tF9Qu9J3Y8TA379Xxg7lWRMiDvc36pRWV1z9/HICv05fXkeeLw1Dg=="
     },
     "unicode-canonical-property-names-ecmascript": {
       "version": "2.0.0",
@@ -26383,11 +26249,6 @@
         "browser-process-hrtime": "^1.0.0"
       }
     },
-    "w3c-keyname": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.4.tgz",
-      "integrity": "sha512-tOhfEwEzFLJzf6d1ZPkYfGj+FWhIpBux9ppoP3rlclw3Z0BZv3N7b7030Z1kYth+6rDuAsXUFr+d0VE6Ed1ikw=="
-    },
     "w3c-xmlserializer": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-2.0.0.tgz",
@@ -26424,6 +26285,11 @@
       "requires": {
         "minimalistic-assert": "^1.0.0"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "4.0.0-beta.1",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.1.tgz",
+      "integrity": "sha512-3ux37gEX670UUphBF9AMCq8XM6iQ8Ac6A+DSRRjDoRBm1ufCkaCDdNVbaqq60PsEkdNlLKrGtv/YBP4EJXqNtQ=="
     },
     "webidl-conversions": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -23,8 +23,8 @@
     "watch": "webpack -w --progress"
   },
   "dependencies": {
-    "codemirror": "^5.48.2",
-    "codemirror-graphql": "^1.0.2",
+    "codemirror": "5.54.0",
+    "codemirror-graphql": "1.0.2",
     "prop-types": "^15.7.2",
     "react-codemirror2": "^7.2.1"
   },


### PR DESCRIPTION
## 🧰 What's being changed?

We're currently having Webpack issues with releases of Codemirror past 5.54.0 so we're temporarily pinning back `codemirror` and `codemirror-graphql` to releases that we know worked previously.

Since the places where we're having issues with it will be going away when we fully deprecate Hub 2 at the end of the year we should be able to bump these back up sometime in January or February.