### PR TITLE
fix: dont variable-ize escaped sequences

### DIFF
--- a/__tests__/codeMirror.test.js
+++ b/__tests__/codeMirror.test.js
@@ -97,6 +97,12 @@ describe('variable substitution', () => {
       'APIKEY NAME'
     );
   });
+
+  it('should NOT tokenize escaped variables', () => {
+    expect(mount(syntaxHighlighter('\\<<wat>>', 'json', { tokenizeVariables: true })).text()).toBe('<<wat>>');
+    expect(mount(syntaxHighlighter('<<wat\\>>', 'json', { tokenizeVariables: true })).text()).toBe('<<wat>>');
+    expect(mount(syntaxHighlighter('\\<<wat\\>>', 'json', { tokenizeVariables: true })).text()).toBe('<<wat>>');
+  });
 });
 
 describe('Supported languages', () => {

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -52,7 +52,7 @@ StructuredOutput.propTypes = {
 /**
  * Generate an array of classNames
  *
- * @arg {[][]{line: Int}} ranges
+ * @arg \{[][]{line: Int}} ranges
  * @return {[String]} Consumable classNames
  */
 const highlightedLines = (ranges, totalLength) => {
@@ -169,9 +169,14 @@ const extractVariables = (code, opts) => {
   let offsetDelta = 0;
   const variables = [];
 
-  const extracter = ({ length }, capture, offset) => {
+  const extracter = (match, capture, offset) => {
+    const unescaped = match.replace(/^\\<</, '<<').replace(/\\>>$/, '>>');
+    if (unescaped !== match) {
+      return unescaped;
+    }
+
     variables.push({ text: capture, offset: offset - offsetDelta });
-    offsetDelta += length;
+    offsetDelta += match.length;
 
     return '';
   };

--- a/src/codeMirror/index.jsx
+++ b/src/codeMirror/index.jsx
@@ -52,7 +52,7 @@ StructuredOutput.propTypes = {
 /**
  * Generate an array of classNames
  *
- * @arg \{[][]{line: Int}} ranges
+ * @arg {[][]{line: Int}} ranges
  * @return {[String]} Consumable classNames
  */
 const highlightedLines = (ranges, totalLength) => {


### PR DESCRIPTION
| 🚥 Resolves CX-138 |
| :----------------- |

## 🧰 Changes

This PR prevents rendering escaped variables.

## 🧬 QA & Testing

Consider the following markdown:

````
```
somebash \<< not a var >> log.txt
```
````
