### PR TITLE
feat!: externalize codemirror, react-codemirror2, and prop-types (semver-major)

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,23 +33,40 @@ const base = {
   optimization: {
     minimize: true,
   },
-  externals: {
-    react: {
-      root: 'React',
-      commonjs2: 'react',
-      commonjs: 'react',
-      amd: 'react',
-      umd: 'react',
+  externals: [
+    {
+      react: {
+        root: 'React',
+        commonjs2: 'react',
+        commonjs: 'react',
+        amd: 'react',
+        umd: 'react',
+      },
+      'react-dom': {
+        root: 'ReactDOM',
+        commonjs2: 'react-dom',
+        commonjs: 'react-dom',
+        amd: 'react-dom',
+        umd: 'react-dom',
+      },
+      '@readme/variable': '@readme/variable',
+      codemirror: 'codemirror',
+      'react-codemirror2': 'react-codemirror2',
+      'prop-types': 'prop-types',
     },
-    'react-dom': {
-      root: 'ReactDOM',
-      commonjs2: 'react-dom',
-      commonjs: 'react-dom',
-      amd: 'react-dom',
-      umd: 'react-dom',
+    // `codemirror`, `react-codemirror2`, and `prop-types` are runtime `dependencies` that every
+    // consumer already installs, so bundling them too is double-shipping. This externalizes deep
+    // requires as well (mode/addon files, `codemirror/lib/codemirror`), so the consumer's own
+    // bundler resolves them from its own `node_modules`. CSS imports (e.g.
+    // `codemirror/addon/scroll/simplescrollbars.css`) stay bundled via style-loader so consumers
+    // don't need their own CSS handling for our node_modules imports.
+    ({ request }, callback) => {
+      if (request.startsWith('codemirror/') && !request.endsWith('.css')) {
+        return callback(null, `commonjs2 ${request}`);
+      }
+      callback();
     },
-    '@readme/variable': '@readme/variable',
-  },
+  ],
   resolve: {
     extensions: ['.js', '.jsx', '.ts', '.tsx'],
   },


### PR DESCRIPTION
## Summary

Stacked on #647 (Phase 1). This is Phase 2 from the same bundle-size plan: **semver-major**, should not ship until Phase 1 is merged, released, and this has been smoke-tested in the main readme app.

- `codemirror`, `react-codemirror2`, and `prop-types` are already runtime `dependencies` — every consumer installs them — yet they were also compiled into `dist/index.js`. That's double-shipping, and it prevented the consumer's own bundler from deduping CodeMirror against any other copy already in their app.
- Extends `externals` in `webpack.config.js` (same precedent as the existing `react`/`react-dom`/`@readme/variable` entries) to cover `codemirror`, `react-codemirror2`, `prop-types`, plus a function external for deep requires (`codemirror/mode/*/*`, `codemirror/addon/*`, `codemirror/lib/codemirror`) — excluding `.css` imports, which stay bundled via `style-loader` so consumers don't need their own CSS handling for our `node_modules` imports.
- `dist/index.node.js` is unaffected — `src/index.node.ts` only imports the pure utils, no CodeMirror.

Result, on top of Phase 1's ~510 KB / ~158 KB gzip:

| State | Raw | Gzip |
|---|---|---|
| Phase 1 only (#647) | ~510 KB | ~158 KB |
| + this PR | 47.2 KB | 14.5 KB |

The published bundle becomes just ReadMe's own code + CSS. Consumers still load CodeMirror, but exactly one copy, resolved and tree-shaken by their own build.

## Test plan

- [x] `npm test` — full vitest suite passes (294 tests)
- [x] `npm run build` — `dist/index.js` is 47,200 bytes raw / 14,557 bytes gzip
- [x] `npm pack`, installed the tarball into a scratch consumer with real `codemirror`/`react`/`prop-types`/`react-codemirror2` deps
- [x] Built a **second, separate webpack config** in that scratch consumer that imports `@readme/syntax-highlighter/browser` and bundles it — confirmed the consumer's own webpack resolves `codemirror` (907 KB, 41 modules) from **its own** `node_modules`, proving the externalized `require()` calls pass through correctly
- [x] Executed the resulting consumer bundle in `jsdom` and rendered a `graphql` and a `javascript` sample — output tokenizes identically to Phase 1 / `main`
- [ ] Smoke-test in the actual main readme app before this is released (not done here — needs a maintainer with access to that repo)

## Not in scope

- Lazy per-language mode loading and a CodeMirror 6/Lezer migration remain future options, not addressed here.